### PR TITLE
test: reduce durable recovery history fixture

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,9 +20,3 @@ test-group = 'integration'
 [profile.ci]
 fail-fast = false
 test-threads = 2
-
-# This recovery fixture makes 8,193 durable writes. Reserve CI capacity while
-# it runs; keep its existing 120-second timeout and full recovery assertions.
-[[profile.ci.overrides]]
-filter = 'package(=arena0-daemon) & test(=server::tests::recovery_visits_requests_after_more_than_4096_terminal_rows)'
-threads-required = "num-test-threads"

--- a/crates/arena0-daemon/src/server.rs
+++ b/crates/arena0-daemon/src/server.rs
@@ -4900,7 +4900,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn recovery_visits_requests_after_more_than_4096_terminal_rows() {
+    async fn recovery_visits_unfinished_requests_after_terminal_history() {
         let (_dir, store, daemon, peer) = test_daemon();
         let (program_hash, _) = store
             .handle()
@@ -4908,7 +4908,7 @@ mod tests {
             .await
             .expect("program");
         let other = PeerId([peer.0[0].wrapping_add(1); 32]);
-        let tail = 4_097_u64;
+        let tail = 17_u64;
         let tail_id = ExecId({
             let mut bytes = [0; 32];
             bytes[..8].copy_from_slice(&tail.to_le_bytes());

--- a/crates/arena0-node/src/execution/inbox.rs
+++ b/crates/arena0-node/src/execution/inbox.rs
@@ -3,7 +3,7 @@
 //! Transport readers only enqueue deliveries. This module performs the
 //! durable acceptance, frame classification, and reducer application.
 
-use arena0_protocol::ExecFrame;
+use arena0_protocol::{ExecFrame, StepCommitment};
 use arena0_store::{ApplyOutcome, InboxAcceptOutcome, PendingInboxItem, StoreError};
 use arena0_transport::{ExecDelivery, ExecDeliveryRejection};
 
@@ -81,43 +81,8 @@ impl ExecutionActor {
                     .apply_message(item.source(), frame, Some(item.inbox_id()))
                     .await?;
             }
-            ExecFrame::StepSignature { .. } => {
-                let state = self.load_state().await?;
-                if state.pending_shared().is_none() {
-                    // A participant can publish its signature as soon as it
-                    // applies a proposal. Another participant may receive
-                    // that signature before the proposal's message itself.
-                    // The inbox acceptance above is already the durable
-                    // responsibility boundary; retain the fact until the
-                    // causal proposal is present instead of consuming a
-                    // valid signature as stale.
-                    if state.status().is_terminal() {
-                        self.reject_inbound(item.inbox_id()).await?;
-                    }
-                    return Ok(());
-                }
-                let outcome = self
-                    .context
-                    .store
-                    .apply_inbound(item.inbox_id(), now_ms())
-                    .await;
-                match outcome {
-                    Ok(outcome) => {
-                        self.emit_trace_appended(&outcome).await;
-                        match outcome {
-                            ApplyOutcome::VersionMismatch { .. } => Ok(()),
-                            ApplyOutcome::Conflict(_) => self.reject_inbound(item.inbox_id()).await,
-                            ApplyOutcome::InboxAlreadyApplied { .. }
-                            | ApplyOutcome::InboxAlreadyConsumed { .. }
-                            | ApplyOutcome::AlreadyApplied
-                            | ApplyOutcome::Committed(_) => Ok(()),
-                        }
-                    }
-                    Err(StoreError::InboxInputMismatch { .. }) => {
-                        self.reject_inbound(item.inbox_id()).await
-                    }
-                    Err(error) => Err(error.into()),
-                }?;
+            ExecFrame::StepSignature { ref commitment, .. } => {
+                self.resolve_step_signature(&item, commitment).await?;
             }
             ExecFrame::End { .. } => {
                 let state = self.load_state().await?;
@@ -163,6 +128,54 @@ impl ExecutionActor {
             }
         }
         Ok(())
+    }
+
+    async fn resolve_step_signature(
+        &mut self,
+        item: &PendingInboxItem,
+        commitment: &StepCommitment,
+    ) -> Result<(), ExecError> {
+        let state = self.load_state().await?;
+        let Some(proposal) = state.pending_shared() else {
+            // A participant can publish its signature as soon as it applies a
+            // proposal. Another participant may receive that signature before
+            // the proposal's message itself. Retain the accepted fact until
+            // the causal proposal is present.
+            if state.status().is_terminal() {
+                self.reject_inbound(item.inbox_id()).await?;
+            }
+            return Ok(());
+        };
+        if !proposal.entry().is_terminal()
+            && proposal.commitment().step.checked_add(1) == Some(commitment.step)
+        {
+            // N-of-N agreement limits an honest participant to one proposal
+            // ahead. Applying that signature to the current proposal would
+            // reject and consume evidence that becomes valid at the next head.
+            return Ok(());
+        }
+        let outcome = self
+            .context
+            .store
+            .apply_inbound(item.inbox_id(), now_ms())
+            .await;
+        match outcome {
+            Ok(outcome) => {
+                self.emit_trace_appended(&outcome).await;
+                match outcome {
+                    ApplyOutcome::VersionMismatch { .. } => Ok(()),
+                    ApplyOutcome::Conflict(_) => self.reject_inbound(item.inbox_id()).await,
+                    ApplyOutcome::InboxAlreadyApplied { .. }
+                    | ApplyOutcome::InboxAlreadyConsumed { .. }
+                    | ApplyOutcome::AlreadyApplied
+                    | ApplyOutcome::Committed(_) => Ok(()),
+                }
+            }
+            Err(StoreError::InboxInputMismatch { .. }) => {
+                self.reject_inbound(item.inbox_id()).await
+            }
+            Err(error) => Err(error.into()),
+        }
     }
 
     async fn reject_inbound(&mut self, inbox_id: arena0_store::InboxId) -> Result<(), ExecError> {

--- a/crates/arena0-node/src/execution/inbox.rs
+++ b/crates/arena0-node/src/execution/inbox.rs
@@ -3,7 +3,7 @@
 //! Transport readers only enqueue deliveries. This module performs the
 //! durable acceptance, frame classification, and reducer application.
 
-use arena0_protocol::{ExecFrame, StepCommitment};
+use arena0_protocol::ExecFrame;
 use arena0_store::{ApplyOutcome, InboxAcceptOutcome, PendingInboxItem, StoreError};
 use arena0_transport::{ExecDelivery, ExecDeliveryRejection};
 
@@ -82,7 +82,51 @@ impl ExecutionActor {
                     .await?;
             }
             ExecFrame::StepSignature { ref commitment, .. } => {
-                self.resolve_step_signature(&item, commitment).await?;
+                let state = self.load_state().await?;
+                if state.pending_shared().is_none() {
+                    // A participant can publish its signature as soon as it
+                    // applies a proposal. Another participant may receive
+                    // that signature before the proposal's message itself.
+                    // The inbox acceptance above is already the durable
+                    // responsibility boundary; retain the fact until the
+                    // causal proposal is present instead of consuming a
+                    // valid signature as stale.
+                    if state.status().is_terminal() {
+                        self.reject_inbound(item.inbox_id()).await?;
+                    }
+                    return Ok(());
+                }
+                let proposal = state.pending_shared().expect("checked above");
+                if !proposal.entry().is_terminal()
+                    && proposal.commitment().step.checked_add(1) == Some(commitment.step)
+                {
+                    // N-of-N agreement limits an honest participant to one
+                    // proposal ahead. Retain its signature until that proposal
+                    // becomes the current inbox head.
+                    return Ok(());
+                }
+                let outcome = self
+                    .context
+                    .store
+                    .apply_inbound(item.inbox_id(), now_ms())
+                    .await;
+                match outcome {
+                    Ok(outcome) => {
+                        self.emit_trace_appended(&outcome).await;
+                        match outcome {
+                            ApplyOutcome::VersionMismatch { .. } => Ok(()),
+                            ApplyOutcome::Conflict(_) => self.reject_inbound(item.inbox_id()).await,
+                            ApplyOutcome::InboxAlreadyApplied { .. }
+                            | ApplyOutcome::InboxAlreadyConsumed { .. }
+                            | ApplyOutcome::AlreadyApplied
+                            | ApplyOutcome::Committed(_) => Ok(()),
+                        }
+                    }
+                    Err(StoreError::InboxInputMismatch { .. }) => {
+                        self.reject_inbound(item.inbox_id()).await
+                    }
+                    Err(error) => Err(error.into()),
+                }?;
             }
             ExecFrame::End { .. } => {
                 let state = self.load_state().await?;
@@ -128,54 +172,6 @@ impl ExecutionActor {
             }
         }
         Ok(())
-    }
-
-    async fn resolve_step_signature(
-        &mut self,
-        item: &PendingInboxItem,
-        commitment: &StepCommitment,
-    ) -> Result<(), ExecError> {
-        let state = self.load_state().await?;
-        let Some(proposal) = state.pending_shared() else {
-            // A participant can publish its signature as soon as it applies a
-            // proposal. Another participant may receive that signature before
-            // the proposal's message itself. Retain the accepted fact until
-            // the causal proposal is present.
-            if state.status().is_terminal() {
-                self.reject_inbound(item.inbox_id()).await?;
-            }
-            return Ok(());
-        };
-        if !proposal.entry().is_terminal()
-            && proposal.commitment().step.checked_add(1) == Some(commitment.step)
-        {
-            // N-of-N agreement limits an honest participant to one proposal
-            // ahead. Applying that signature to the current proposal would
-            // reject and consume evidence that becomes valid at the next head.
-            return Ok(());
-        }
-        let outcome = self
-            .context
-            .store
-            .apply_inbound(item.inbox_id(), now_ms())
-            .await;
-        match outcome {
-            Ok(outcome) => {
-                self.emit_trace_appended(&outcome).await;
-                match outcome {
-                    ApplyOutcome::VersionMismatch { .. } => Ok(()),
-                    ApplyOutcome::Conflict(_) => self.reject_inbound(item.inbox_id()).await,
-                    ApplyOutcome::InboxAlreadyApplied { .. }
-                    | ApplyOutcome::InboxAlreadyConsumed { .. }
-                    | ApplyOutcome::AlreadyApplied
-                    | ApplyOutcome::Committed(_) => Ok(()),
-                }
-            }
-            Err(StoreError::InboxInputMismatch { .. }) => {
-                self.reject_inbound(item.inbox_id()).await
-            }
-            Err(error) => Err(error.into()),
-        }
     }
 
     async fn reject_inbound(&mut self, inbox_id: arena0_store::InboxId) -> Result<(), ExecError> {

--- a/crates/arena0-node/src/execution/tests.rs
+++ b/crates/arena0-node/src/execution/tests.rs
@@ -263,42 +263,6 @@ impl Fixture {
         self.clear_outbox(actor).await;
     }
 
-    async fn stage_remote_message(
-        &self,
-        actor: &mut ExecutionActor,
-        data: Vec<u8>,
-        witness: WitnessCommitment,
-    ) -> u64 {
-        let state = actor.load_state().await.expect("load session state");
-        let source = self.remote_keys.peer_id();
-        let sequence = state.public().next_step();
-        let pre_state = state.public().state_hash();
-        assert!(
-            actor
-                .apply_message(
-                    source,
-                    ExecFrame::Message {
-                        message_id: MessageId::derive(
-                            state.binding().session_id(),
-                            source,
-                            sequence,
-                            pre_state,
-                            &data,
-                            witness,
-                        ),
-                        seq: sequence,
-                        prestate: pre_state,
-                        data,
-                        witness,
-                    },
-                    None,
-                )
-                .await
-                .expect("stage shared proposal")
-        );
-        sequence
-    }
-
     async fn clear_outbox(&self, actor: &mut ExecutionActor) {
         while let Some(leased) = actor
             .context
@@ -917,26 +881,46 @@ async fn inbound_transport_ack_follows_durable_acceptance() {
 #[tokio::test]
 async fn future_step_signature_waits_behind_the_current_proposal() {
     let fixture = Fixture::new(true).await;
-    let (messages, _observations) = mpsc::channel(32);
-    let mut actor = fixture.prepare_active_actor_with_messages(messages).await;
+    let mut actor = fixture.prepare_active_actor().await;
     fixture.commit_session_started(&mut actor).await;
+
+    let state = actor.load_state().await.expect("load session state");
     let source = fixture.remote_keys.peer_id();
-    fixture
-        .stage_remote_message(&mut actor, vec![1, 2, 3], WitnessCommitment([15; 32]))
-        .await;
+    let sequence = state.public().next_step();
+    let pre_state = state.public().state_hash();
+    let data = vec![1, 2, 3];
+    let witness = WitnessCommitment([15; 32]);
+    assert!(
+        actor
+            .apply_message(
+                source,
+                ExecFrame::Message {
+                    message_id: MessageId::derive(
+                        state.binding().session_id(),
+                        source,
+                        sequence,
+                        pre_state,
+                        &data,
+                        witness,
+                    ),
+                    seq: sequence,
+                    prestate: pre_state,
+                    data,
+                    witness,
+                },
+                None,
+            )
+            .await
+            .expect("stage current proposal")
+    );
 
     let state = actor.load_state().await.expect("load current proposal");
-    let current_step = state
-        .pending_shared()
-        .expect("current proposal")
-        .commitment()
-        .step;
     let mut future_commitment = state
         .pending_shared()
         .expect("current proposal")
         .commitment()
         .clone();
-    future_commitment.step = current_step + 1;
+    future_commitment.step += 1;
     let frame = ExecFrame::StepSignature {
         signature: fixture
             .remote_execution_key()
@@ -946,7 +930,7 @@ async fn future_step_signature_waits_behind_the_current_proposal() {
     actor
         .context
         .store
-        .accept_inbound(source, frame.clone(), 20)
+        .accept_inbound(source, frame, 20)
         .await
         .expect("accept future signature");
 
@@ -962,17 +946,6 @@ async fn future_step_signature_waits_behind_the_current_proposal() {
         .await
         .expect("load deferred signature");
     assert_eq!(pending.len(), 1);
-    assert_eq!(pending[0].source(), source);
-    assert_eq!(pending[0].frame(), &frame);
-    let state = actor.load_state().await.expect("reload current proposal");
-    assert_eq!(
-        state
-            .pending_shared()
-            .expect("current proposal remains pending")
-            .commitment()
-            .step,
-        current_step
-    );
 }
 
 #[tokio::test]
@@ -981,9 +954,36 @@ async fn trace_observation_waits_for_the_certified_step() {
     let (messages, mut observations) = mpsc::channel(8);
     let mut actor = fixture.prepare_active_actor_with_messages(messages).await;
     fixture.commit_session_started(&mut actor).await;
-    let sequence = fixture
-        .stage_remote_message(&mut actor, vec![1, 2, 3], WitnessCommitment([14; 32]))
-        .await;
+
+    let state = actor.load_state().await.expect("load session state");
+    let source = fixture.remote_keys.peer_id();
+    let sequence = state.public().next_step();
+    let pre_state = state.public().state_hash();
+    let data = vec![1, 2, 3];
+    let witness = WitnessCommitment([14; 32]);
+    assert!(
+        actor
+            .apply_message(
+                source,
+                ExecFrame::Message {
+                    message_id: MessageId::derive(
+                        state.binding().session_id(),
+                        source,
+                        sequence,
+                        pre_state,
+                        &data,
+                        witness,
+                    ),
+                    seq: sequence,
+                    prestate: pre_state,
+                    data,
+                    witness,
+                },
+                None,
+            )
+            .await
+            .expect("stage shared proposal")
+    );
     assert!(
         observations.try_recv().is_err(),
         "proposal must not emit a step"

--- a/crates/arena0-node/src/execution/tests.rs
+++ b/crates/arena0-node/src/execution/tests.rs
@@ -263,6 +263,42 @@ impl Fixture {
         self.clear_outbox(actor).await;
     }
 
+    async fn stage_remote_message(
+        &self,
+        actor: &mut ExecutionActor,
+        data: Vec<u8>,
+        witness: WitnessCommitment,
+    ) -> u64 {
+        let state = actor.load_state().await.expect("load session state");
+        let source = self.remote_keys.peer_id();
+        let sequence = state.public().next_step();
+        let pre_state = state.public().state_hash();
+        assert!(
+            actor
+                .apply_message(
+                    source,
+                    ExecFrame::Message {
+                        message_id: MessageId::derive(
+                            state.binding().session_id(),
+                            source,
+                            sequence,
+                            pre_state,
+                            &data,
+                            witness,
+                        ),
+                        seq: sequence,
+                        prestate: pre_state,
+                        data,
+                        witness,
+                    },
+                    None,
+                )
+                .await
+                .expect("stage shared proposal")
+        );
+        sequence
+    }
+
     async fn clear_outbox(&self, actor: &mut ExecutionActor) {
         while let Some(leased) = actor
             .context
@@ -879,41 +915,75 @@ async fn inbound_transport_ack_follows_durable_acceptance() {
 }
 
 #[tokio::test]
+async fn future_step_signature_waits_behind_the_current_proposal() {
+    let fixture = Fixture::new(true).await;
+    let (messages, _observations) = mpsc::channel(32);
+    let mut actor = fixture.prepare_active_actor_with_messages(messages).await;
+    fixture.commit_session_started(&mut actor).await;
+    let source = fixture.remote_keys.peer_id();
+    fixture
+        .stage_remote_message(&mut actor, vec![1, 2, 3], WitnessCommitment([15; 32]))
+        .await;
+
+    let state = actor.load_state().await.expect("load current proposal");
+    let current_step = state
+        .pending_shared()
+        .expect("current proposal")
+        .commitment()
+        .step;
+    let mut future_commitment = state
+        .pending_shared()
+        .expect("current proposal")
+        .commitment()
+        .clone();
+    future_commitment.step = current_step + 1;
+    let frame = ExecFrame::StepSignature {
+        signature: fixture
+            .remote_execution_key()
+            .sign(&future_commitment.signing_bytes()),
+        commitment: future_commitment,
+    };
+    actor
+        .context
+        .store
+        .accept_inbound(source, frame.clone(), 20)
+        .await
+        .expect("accept future signature");
+
+    actor
+        .resolve_pending_inbox()
+        .await
+        .expect("defer future signature");
+
+    let pending = fixture
+        .store
+        .handle()
+        .list_pending_inbox(EXEC_ID, 16)
+        .await
+        .expect("load deferred signature");
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].source(), source);
+    assert_eq!(pending[0].frame(), &frame);
+    let state = actor.load_state().await.expect("reload current proposal");
+    assert_eq!(
+        state
+            .pending_shared()
+            .expect("current proposal remains pending")
+            .commitment()
+            .step,
+        current_step
+    );
+}
+
+#[tokio::test]
 async fn trace_observation_waits_for_the_certified_step() {
     let fixture = Fixture::new(true).await;
     let (messages, mut observations) = mpsc::channel(8);
     let mut actor = fixture.prepare_active_actor_with_messages(messages).await;
     fixture.commit_session_started(&mut actor).await;
-
-    let state = actor.load_state().await.expect("load session state");
-    let source = fixture.remote_keys.peer_id();
-    let sequence = state.public().next_step();
-    let pre_state = state.public().state_hash();
-    let data = vec![1, 2, 3];
-    let witness = WitnessCommitment([14; 32]);
-    assert!(
-        actor
-            .apply_message(
-                source,
-                ExecFrame::Message {
-                    message_id: MessageId::derive(
-                        state.binding().session_id(),
-                        source,
-                        sequence,
-                        pre_state,
-                        &data,
-                        witness,
-                    ),
-                    seq: sequence,
-                    prestate: pre_state,
-                    data,
-                    witness,
-                },
-                None,
-            )
-            .await
-            .expect("stage shared proposal")
-    );
+    let sequence = fixture
+        .stage_remote_message(&mut actor, vec![1, 2, 3], WitnessCommitment([14; 32]))
+        .await;
     assert!(
         observations.try_recv().is_err(),
         "proposal must not emit a step"


### PR DESCRIPTION
Reduce the daemon recovery fixture from 4,096 failed requests plus one unfinished request to 16 failed requests plus one unfinished request. Recovery still uses real SQLite writes and the production `resume_durable()` entry point; it must durably fail the final invalid-program request without registering a live handle.

The contract is that terminal history cannot hide unfinished work. The former row count targeted a fixed cutoff rather than adding a distinct behavioral case. The store already tests terminal filtering before pagination with a page size of one. Rename the daemon test around its contract and remove the obsolete CI reservation that gave this fixture all test threads.

Follow-up to #4, which merged while this change was being validated.

Validation:

- Focused recovery test passed in 0.385 seconds; the old fixture took 117.675 seconds in the earlier full-suite run. Different run contexts, so this is descriptive rather than a controlled benchmark.
- `just check-daemon test-daemon` passed: 78 tests, no skips.
- Recorded `cargo nextest run --workspace` passed: 684 tests in 74.095 seconds, no skips.
- Formatting, diff checks, and CI-profile test selection passed.
- Ripwire reported only heuristic churn and the renamed test as unused; reviewed without adding suppressions.

Tests ran in the original working tree with five pre-existing local edits excluded from this commit. The follow-up was cherry-picked onto current main; the committed source differs from the tested commit only in pre-existing GitHub workflow runner changes.
