### PR TITLE
refactor: align program import and loading terminology

### DIFF
--- a/crates/arena0-cli/src/coordinated.rs
+++ b/crates/arena0-cli/src/coordinated.rs
@@ -393,8 +393,8 @@ impl Coordinator {
         );
         let connections = connected?;
         let started = Instant::now();
-        let admitted = progress
-            .during(RunStage::Admission, connections.len(), async {
+        let resolved = progress
+            .during(RunStage::ProgramResolution, connections.len(), async {
                 tokio::select! {
                     result = resolve_program(&connections, &request.program, &progress) => result,
                     reason = wait_for_cancel_reason(&mut signal_received) => {
@@ -405,18 +405,18 @@ impl Coordinator {
             })
             .await;
         record_stage(
-            "admit_program",
+            "resolve_program",
             started,
             connections.len(),
-            admitted.is_ok(),
-            admitted
+            resolved.is_ok(),
+            resolved
                 .as_ref()
                 .ok()
                 .map(|program| program.summary.program_hash),
             None,
             None,
         );
-        let program = admitted?;
+        let program = resolved?;
         let program_id = program.summary.program_hash;
         validate_participant_count(&program.summary, connections.len())?;
 
@@ -757,7 +757,7 @@ impl Coordinator {
         let agreement = compare_evidence(&receipts)?;
         if agreement.program_id != program_id {
             bail!(
-                "receipt program {} disagrees with admitted program {}",
+                "receipt program {} disagrees with selected program {}",
                 agreement.program_id,
                 program_id
             );
@@ -1084,7 +1084,7 @@ async fn resolve_program(
         .collect::<Vec<Option<ProgramDetail>>>();
     while let Some(joined) = jobs.join_next().await {
         progress.advance();
-        let (index, detail) = joined.context("program admission task failed to join")??;
+        let (index, detail) = joined.context("program resolution task failed to join")??;
         resolved[index] = Some(detail);
     }
 
@@ -3004,15 +3004,15 @@ mod tests {
                 }
             })
             .await;
-        let admitted = progress
+        let resolved = progress
             .during(
-                RunStage::Admission,
+                RunStage::ProgramResolution,
                 connections.len(),
                 resolve_program(&connections, "scripted", &progress),
             )
             .await
-            .expect("scripted admission");
-        assert_eq!(admitted.summary.program_hash, program_id);
+            .expect("scripted program resolution");
+        assert_eq!(resolved.summary.program_hash, program_id);
 
         let (_creation_cancel, mut creation_cancelled) = watch::channel(None);
         let participants = progress
@@ -3100,7 +3100,7 @@ mod tests {
             let observations = run_scripted_coordinator(replay).await;
             for stage in [
                 RunStage::Connecting,
-                RunStage::Admission,
+                RunStage::ProgramResolution,
                 RunStage::Negotiation,
                 RunStage::Activation,
                 receipt_stage,

--- a/crates/arena0-cli/src/progress.rs
+++ b/crates/arena0-cli/src/progress.rs
@@ -42,7 +42,7 @@ impl ProgressMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RunStage {
     Connecting,
-    Admission,
+    ProgramResolution,
     Negotiation,
     Activation,
     Execution,
@@ -54,7 +54,7 @@ impl RunStage {
     const fn label(self) -> &'static str {
         match self {
             Self::Connecting => "connecting to Hosts",
-            Self::Admission => "admitting program",
+            Self::ProgramResolution => "resolving program",
             Self::Negotiation => "negotiating execution",
             Self::Activation => "activating session",
             Self::Execution => "waiting for execution",

--- a/crates/arena0-client/src/answer.rs
+++ b/crates/arena0-client/src/answer.rs
@@ -1,7 +1,6 @@
 //! Agent answer and `--param` assembly.
 //!
-//! Clients preserve JSON values and leave schema validation to the daemon, the
-//! boundary that owns program admission and execution.
+//! Clients preserve JSON values and leave schema validation to the daemon.
 
 use serde_json::{Map, Value};
 

--- a/crates/arena0-daemon/src/catalog.rs
+++ b/crates/arena0-daemon/src/catalog.rs
@@ -15,8 +15,8 @@ use thiserror::Error;
 /// Maximum catalog rows materialized by one API projection.
 const PROGRAM_LIST_LIMIT: usize = 1_024;
 
-/// Errors at the program-import boundary. A malformed or inadmissible Wasm
-/// artifact is caller input; only the durable registration operation can be a
+/// Errors at the program-import boundary. A malformed or invalid Wasm artifact
+/// is caller input; only the durable registration operation can be a
 /// persistence failure.
 #[derive(Debug, Error)]
 pub(crate) enum CatalogError {
@@ -144,8 +144,10 @@ impl ProgramCatalog {
         Ok(self.detail(hash).await?.map(|detail| detail.schema))
     }
 
-    /// Admit and durably register one artifact. The engine retains compiled
-    /// code; every execution still receives a fresh guest instance.
+    /// Import and durably register one artifact. Validation occurs before
+    /// catalog registration; the engine may retain compiled code for later
+    /// execution loads, and every execution still receives a fresh guest
+    /// instance.
     pub(crate) async fn import(
         &self,
         wasm: Vec<u8>,
@@ -153,8 +155,8 @@ impl ProgramCatalog {
         now_ms: u64,
     ) -> Result<(ProgramHash, ProgramStoreOutcome), CatalogError> {
         let program = Program::try_from(wasm).map_err(CatalogError::InvalidProgram)?;
-        let _admitted = engine
-            .admit(&program)
+        let _loaded = engine
+            .load(&program)
             .map_err(CatalogError::InvalidProgram)?;
         self.store
             .register_program(program.bytes().to_vec(), now_ms)
@@ -162,8 +164,8 @@ impl ProgramCatalog {
             .map_err(CatalogError::Storage)
     }
 
-    /// Remove a program from new-admission membership while retaining bytes
-    /// needed by existing durable executions.
+    /// Remove a program from the active catalog while retaining bytes needed by
+    /// existing durable executions.
     pub(crate) async fn remove(
         &self,
         hash: ProgramHash,

--- a/crates/arena0-daemon/src/ensemble.rs
+++ b/crates/arena0-daemon/src/ensemble.rs
@@ -1289,13 +1289,13 @@ async fn bootstrap_programs(
         let engine = Arc::clone(engine);
         let program = tokio::task::spawn_blocking(move || {
             let program = Program::try_from((*wasm).to_vec()).context("parse embedded program")?;
-            let _admitted = engine
-                .admit(&program)
-                .map_err(|error| anyhow::anyhow!("admit embedded program: {error}"))?;
+            let _loaded = engine
+                .load(&program)
+                .map_err(|error| anyhow::anyhow!("import embedded program: {error}"))?;
             Ok::<_, anyhow::Error>(program)
         })
         .await
-        .context("join embedded program admission")??;
+        .context("join embedded program import")??;
         config
             .store
             .handle()
@@ -1396,7 +1396,7 @@ mod construction_tests {
             true,
         ));
         // Observe real construction after it opens its stores, while bundled
-        // program admission is still running. No synthetic store owner stands
+        // program import is still running. No synthetic store owner stands
         // in for the operation being cancelled.
         tokio::time::timeout(Duration::from_secs(30), async {
             while !home

--- a/crates/arena0-daemon/src/server.rs
+++ b/crates/arena0-daemon/src/server.rs
@@ -43,7 +43,7 @@ use arena0_protocol::{
     PendingId, ReceiptArtifact, SessionHash, StateHash, TerminalKind, Ticket, TicketAction,
     TicketData, TicketHash, Viewport, system_event::SystemEvent,
 };
-use arena0_sandbox::{AdmittedProgram, InitializeCall, Program, ViewCall, WasmtimeEngine};
+use arena0_sandbox::{InitializeCall, LoadedProgram, Program, ViewCall, WasmtimeEngine};
 use arena0_transport::{NegotiationTopic, ProgramTopicEvent, Transport};
 use arena0_verify::{LightVerifiedTerminal as VerifiedLightTerminal, verify_full, verify_light};
 use retry::delay::{Exponential, jitter};
@@ -351,7 +351,7 @@ fn validate_participants(participants: ParticipantCount, target_size: u16) -> Re
 /// A confirmed execution ready for the supervisor.
 struct SpawnPlan {
     params: Vec<u8>,
-    program: Arc<AdmittedProgram>,
+    program: Arc<LoadedProgram>,
     committed: ActivatedSession,
     actor_execution_key: ExecutionKey,
     execution_store: HostExecutionStore,
@@ -1023,39 +1023,39 @@ fn offer_timeout() -> ApiError {
     )
 }
 
-/// Admit one immutable program and initialize it with the exact JSON
+/// Load one imported program and initialize it with the exact JSON
 /// parameters that will be bound by negotiation.  Initialization is a typed
 /// guest call: no mutable Wasmtime instance crosses this daemon boundary.
-fn admit_and_initialize(
+fn load_and_initialize(
     program: &Program,
     engine: &WasmtimeEngine,
     params: Vec<u8>,
     context: &str,
-) -> anyhow::Result<(Arc<AdmittedProgram>, StateHash)> {
-    let admitted = engine
-        .admit(program)
-        .map_err(|error| anyhow::anyhow!("{context} admission: {error}"))?;
+) -> anyhow::Result<(Arc<LoadedProgram>, StateHash)> {
+    let loaded = engine
+        .load(program)
+        .map_err(|error| anyhow::anyhow!("{context} program load: {error}"))?;
     let params =
         JsonBytes::try_new(params).map_err(|error| anyhow::anyhow!("{context} params: {error}"))?;
-    let initialized = admitted
+    let initialized = loaded
         .initialize(InitializeCall::new(params))
         .map_err(|error| anyhow::anyhow!("{context} initialize: {error}"))?;
-    Ok((admitted, StateHash::of(initialized.shared.as_bytes())))
+    Ok((loaded, StateHash::of(initialized.shared.as_bytes())))
 }
 
-/// Admit and initialize one program in a blocking worker. Wasmtime admission
-/// and guest execution are synchronous, while request/negotiation orchestration
+/// Load and initialize one program in a blocking worker. Wasmtime loading and
+/// guest execution are synchronous, while request/negotiation orchestration
 /// remains on the async daemon runtime.
-async fn admit_for(
+async fn load_for(
     program: &Program,
     engine: Arc<WasmtimeEngine>,
     params: Vec<u8>,
     context: &str,
-) -> Result<(Arc<AdmittedProgram>, StateHash), ApiError> {
+) -> Result<(Arc<LoadedProgram>, StateHash), ApiError> {
     let program = program.clone();
     let context = context.to_owned();
     let error_context = context.clone();
-    tokio::task::spawn_blocking(move || admit_and_initialize(&program, &engine, params, &context))
+    tokio::task::spawn_blocking(move || load_and_initialize(&program, &engine, params, &context))
         .await
         .map_err(|error| {
             ApiError::new(ApiErrorCode::Internal, format!("{error_context}: {error}"))
@@ -1063,15 +1063,15 @@ async fn admit_for(
         .map_err(|error| ApiError::new(ApiErrorCode::Execution, error.to_string()))
 }
 
-/// Re-admit a committed program and verify the immutable guest's initial
+/// Load a committed program and verify the immutable guest's initial
 /// shared state against the negotiation's locked boot fact.
-async fn admit_checked(
+async fn load_checked(
     program: &Program,
     offer_data: &OfferData,
     engine: Arc<WasmtimeEngine>,
     context: &str,
-) -> Result<Arc<AdmittedProgram>, ApiError> {
-    let (admitted, initial_state) = admit_for(
+) -> Result<Arc<LoadedProgram>, ApiError> {
+    let (loaded, initial_state) = load_for(
         program,
         engine,
         offer_data.params.as_bytes().to_vec(),
@@ -1084,7 +1084,7 @@ async fn admit_checked(
             format!("{context} boot facts do not match the local runtime"),
         ));
     }
-    Ok(admitted)
+    Ok(loaded)
 }
 
 /// The API operation owner for one Host.
@@ -1667,7 +1667,7 @@ impl HostService {
                         )
                         .await;
                 };
-                let (admitted, initial_state) = match admit_for(
+                let (loaded, initial_state) = match load_for(
                     &program,
                     Arc::clone(&self.engine),
                     activation.offer().data().params.as_bytes().to_vec(),
@@ -1682,7 +1682,7 @@ impl HostService {
                                 candidate,
                                 execution_present,
                                 format!(
-                                    "committed execution cannot be admitted: {}",
+                                    "committed execution cannot load its program: {}",
                                     error.message
                                 ),
                             )
@@ -1750,7 +1750,7 @@ impl HostService {
                         &entry,
                         SpawnPlan {
                             params: activation.offer().data().params.as_bytes().to_vec(),
-                            program: admitted,
+                            program: loaded,
                             committed,
                             actor_execution_key: actor_key,
                             execution_store,
@@ -3035,8 +3035,8 @@ impl HostService {
                 let params = preferred_params.clone().ok_or_else(|| {
                     ApiError::new(ApiErrorCode::BadRequest, "create requires params")
                 })?;
-                let (_admitted, initial_state) =
-                    admit_for(&program, Arc::clone(&self.engine), params.clone(), "create").await?;
+                let (_loaded, initial_state) =
+                    load_for(&program, Arc::clone(&self.engine), params.clone(), "create").await?;
                 let issued_at = unix_time_ms();
                 // Leave the creator ticket's clock-skew and prepare margins
                 // before the first offer is deserted. That gives the driver
@@ -3214,7 +3214,7 @@ impl HostService {
             recompute_initial_state: Box::new(move |_params: &[u8]| {
                 // The creator's re-offer hook: recompute the program's
                 // initial state for the new params.
-                admit_and_initialize(&recompute_program, &engine, _params.to_vec(), "recompute")
+                load_and_initialize(&recompute_program, &engine, _params.to_vec(), "recompute")
                     .map(|(_, initial_state)| initial_state)
                     .map_err(|error| error.to_string())
             }),
@@ -3247,7 +3247,7 @@ impl HostService {
         );
 
         let offer_data = committed.activation().offer().data().clone();
-        let program = admit_checked(
+        let program = load_checked(
             &program,
             &offer_data,
             Arc::clone(&self.engine),
@@ -3509,7 +3509,7 @@ impl HostService {
             let shared = state.shared_state().clone();
             let projection = tokio::task::spawn_blocking(move || {
                 engine
-                    .admit(&program)?
+                    .load(&program)?
                     .view(ViewCall::new(shared, ensemble, viewport))
             })
             .await
@@ -4215,7 +4215,7 @@ async fn offer_is_usable_for_join(
     // Decode and initialize the offered params before binding the durable
     // target. A preference mismatch remains eligible: the creator may counter
     // it after this offer is authenticated.
-    let Ok((_, initial_state)) = admit_for(
+    let Ok((_, initial_state)) = load_for(
         program,
         engine,
         data.params.as_bytes().to_vec(),

--- a/crates/arena0-node/src/context.rs
+++ b/crates/arena0-node/src/context.rs
@@ -15,7 +15,7 @@ use arena0_protocol::{
     NegotiationTarget, PeerIdSource, PreparedActivation, ReceiptArtifact, SessionHash,
     SharedStateBytes, View,
 };
-use arena0_sandbox::AdmittedProgram;
+use arena0_sandbox::LoadedProgram;
 use arena0_store::{
     AdmissionBindingOutcome, CommitActivationOutcome, CreateExecutionOutcome,
     ExecutionRequestFailureOutcome, ExecutionRequestOutcome, ExecutionStore,
@@ -160,13 +160,13 @@ pub enum SessionMessage {
 ///
 /// The context is consumed by [`crate::Host::spawn`].  It contains no
 /// mutable protocol state: the SQLite [`ExecutionStore`] is the sole writer
-/// for that execution, while the actor owns only this admitted guest and its
+/// for that execution, while the actor owns only this loaded guest and its
 /// live external capabilities.
 pub struct ExecContext {
     /// Stable execution identity.
     pub(crate) exec_id: ExecId,
-    /// Immutable Wasm after sandbox admission.
-    pub(crate) program: Arc<AdmittedProgram>,
+    /// Immutable Wasm loaded by the sandbox.
+    pub(crate) program: Arc<LoadedProgram>,
     /// Exact agent-facing parameters bound by activation.
     pub(crate) params: JsonBytes,
     /// Cryptographically validated activation.
@@ -184,7 +184,7 @@ impl ExecContext {
     #[must_use]
     pub fn new(
         exec_id: ExecId,
-        program: Arc<AdmittedProgram>,
+        program: Arc<LoadedProgram>,
         params: JsonBytes,
         activation: Activation,
         execution_key: ExecutionKey,
@@ -339,7 +339,7 @@ impl std::fmt::Debug for ExecContext {
 /// unrelated to its Host.
 pub(crate) struct ActorContext {
     pub(crate) exec_id: ExecId,
-    pub(crate) program: Arc<AdmittedProgram>,
+    pub(crate) program: Arc<LoadedProgram>,
     pub(crate) params: JsonBytes,
     pub(crate) activation: Activation,
     pub(crate) producer: arena0_protocol::PeerId,

--- a/crates/arena0-node/src/execution/guest.rs
+++ b/crates/arena0-node/src/execution/guest.rs
@@ -1,6 +1,6 @@
 //! Guest-facing calls and private/shared progress transitions.
 //!
-//! Every method here loads a fresh durable snapshot, invokes the admitted
+//! Every method here loads a fresh durable snapshot, invokes the loaded
 //! guest, and commits the resulting protocol delta through the store.
 
 use crate::context::{ExecError, SessionMessage};

--- a/crates/arena0-node/src/execution/mod.rs
+++ b/crates/arena0-node/src/execution/mod.rs
@@ -31,7 +31,7 @@ const MAX_TIMER_BATCH: usize = 16;
 const MAX_INBOX_BATCH: usize = 64;
 const MAX_CAS_RETRIES: usize = 8;
 
-/// Sole live owner of one admitted guest and its external capabilities.
+/// Sole live owner of one loaded guest and its external capabilities.
 ///
 /// The actor is intentionally private: callers interact through the
 /// command and observation handles created by `spawn_execution`.

--- a/crates/arena0-node/src/execution/tests.rs
+++ b/crates/arena0-node/src/execution/tests.rs
@@ -17,7 +17,7 @@ use arena0_protocol::{
     PrivateRecord, PublicEvent, SharedDelta, StateHash, TRACE_FORMAT_VERSION, Ticket, TicketAction,
     TicketData, TicketHash, TraceEntry, WitnessCommitment,
 };
-use arena0_sandbox::{AdmittedProgram, LocalEvent, Program, WasmtimeEngine};
+use arena0_sandbox::{LoadedProgram, LocalEvent, Program, WasmtimeEngine};
 use arena0_store::{Store, StoreConfig};
 use arena0_transport::Transport;
 use arena0_transport::local::{LocalNetwork, LocalTransport};
@@ -128,18 +128,18 @@ impl Fixture {
         }
     }
 
-    fn admitted_program(&self) -> Arc<AdmittedProgram> {
+    fn loaded_program(&self) -> Arc<LoadedProgram> {
         let program = Program::parse(self.wasm.clone()).expect("program");
         WasmtimeEngine::new()
             .expect("sandbox engine")
-            .admit(&program)
-            .expect("admitted program")
+            .load(&program)
+            .expect("loaded program")
     }
 
     fn context(&self) -> ExecContext {
         ExecContext {
             exec_id: EXEC_ID,
-            program: self.admitted_program(),
+            program: self.loaded_program(),
             params: self.params.clone(),
             activation: self.activation.clone(),
             execution_key: self.local_execution_key(),

--- a/crates/arena0-node/src/lib.rs
+++ b/crates/arena0-node/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! One private execution actor is the only runtime owner for each
 //! [`arena0_protocol::ExecId`]. It keeps
-//! an admitted Wasm program and live transport capabilities in memory, while
+//! a loaded Wasm program and live transport capabilities in memory, while
 //! every protocol fact is loaded from and committed through its claimed
 //! [`arena0_store::ExecutionStore`].
 //! The protocol reducer and store are intentionally below this crate; this

--- a/crates/arena0-program/src/profile.rs
+++ b/crates/arena0-program/src/profile.rs
@@ -108,7 +108,7 @@ pub struct CapabilityImport {
 pub struct ImportSemantics {
     /// Wasm module name containing host imports.
     pub host_module: String,
-    /// Imports linked for every admitted program.
+    /// Imports linked for every loaded program.
     pub always_available: Vec<String>,
     /// Capability-gated import bindings.
     pub capability_imports: Vec<CapabilityImport>,

--- a/crates/arena0-program/src/schema.rs
+++ b/crates/arena0-program/src/schema.rs
@@ -102,7 +102,7 @@ impl<'de> Deserialize<'de> for BorshSchemaDocument {
 /// Invalid embedded Borsh schema metadata.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum BorshSchemaDocumentError {
-    /// The encoded schema exceeds arena0's admission bound.
+    /// The encoded schema exceeds arena0's Borsh schema size bound.
     #[error("Borsh schema is {actual} bytes; maximum is {max}")]
     TooLarge { actual: usize, max: usize },
     /// The schema cannot be decoded or violates Borsh's schema invariants.

--- a/crates/arena0-sandbox/src/call.rs
+++ b/crates/arena0-sandbox/src/call.rs
@@ -1,7 +1,7 @@
 //! Typed inputs for fresh guest invocations.
 //!
 //! These values deliberately separate shared, local, and read-only calls.
-//! Constructing a call does not allocate a Wasmtime instance. The admitted
+//! Constructing a call does not allocate a Wasmtime instance. The loaded
 //! program creates and destroys one instance when the call is executed.
 
 use arena0_program::{

--- a/crates/arena0-sandbox/src/engine/instance.rs
+++ b/crates/arena0-sandbox/src/engine/instance.rs
@@ -1,4 +1,4 @@
-//! Program loading and immutable admitted-code ownership.
+//! Program loading and immutable compiled-code ownership.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -44,7 +44,7 @@ impl super::WasmtimeEngine {
         Ok(Self {
             engine,
             profile: ExecutionProfile::current(),
-            admitted: moka::sync::Cache::new(super::ADMISSION_CACHE_CAPACITY),
+            loaded: moka::sync::Cache::new(super::PROGRAM_CACHE_CAPACITY),
             persistent_cache,
         })
     }
@@ -55,8 +55,9 @@ impl super::WasmtimeEngine {
         &self.profile
     }
 
-    /// Compile and validate a completed program artifact.
-    pub fn admit(&self, program: &Program) -> Result<Arc<super::AdmittedProgram>, SandboxError> {
+    /// Load a completed program artifact for execution, compiling and
+    /// validating it as needed.
+    pub fn load(&self, program: &Program) -> Result<Arc<super::LoadedProgram>, SandboxError> {
         let performance_enabled = tracing::enabled!(
             target: "arena0::performance",
             tracing::Level::DEBUG
@@ -70,14 +71,14 @@ impl super::WasmtimeEngine {
                     .map(wasmtime::Cache::cache_hits)
             })
             .flatten();
-        let admitted = self
-            .admitted
+        let loaded = self
+            .loaded
             .entry(program.hash())
             .or_try_insert_with(|| self.compile(program));
 
         if let (Some(started), Some(encoded_size)) = (started, encoded_size) {
             let elapsed_us = u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX);
-            match &admitted {
+            match &loaded {
                 Ok(entry) => {
                     let persistent_hit = persistent_hits_before.is_some_and(|before| {
                         self.persistent_cache
@@ -91,7 +92,7 @@ impl super::WasmtimeEngine {
                     };
                     tracing::debug!(
                         target: "arena0::performance",
-                        operation = "program_admission",
+                        operation = "program_load",
                         version = arena0_program::ABI_VERSION,
                         encoded_size,
                         success = true,
@@ -101,22 +102,22 @@ impl super::WasmtimeEngine {
                 }
                 Err(_) => tracing::debug!(
                     target: "arena0::performance",
-                    operation = "program_admission",
+                    operation = "program_load",
                     version = arena0_program::ABI_VERSION,
                     encoded_size,
                     success = false,
-                    result_class = "admission_error",
+                    result_class = "load_error",
                     elapsed_us,
                 ),
             }
         }
 
-        admitted
+        loaded
             .map(|entry| entry.into_value())
             .map_err(Arc::unwrap_or_clone)
     }
 
-    fn compile(&self, program: &Program) -> Result<Arc<super::AdmittedProgram>, SandboxError> {
+    fn compile(&self, program: &Program) -> Result<Arc<super::LoadedProgram>, SandboxError> {
         let module = Module::new(&self.engine, program.bytes())
             .map_err(|error| SandboxError::compilation_failed(error.to_string()))?;
         validation::validate_exports(&module)?;
@@ -133,7 +134,7 @@ impl super::WasmtimeEngine {
                 random_replay: None,
             },
         )?;
-        Ok(Arc::new(super::AdmittedProgram {
+        Ok(Arc::new(super::LoadedProgram {
             engine: self.engine.clone(),
             module,
             program: program.clone(),
@@ -208,8 +209,8 @@ impl super::WasmtimeEngine {
     }
 }
 
-impl super::AdmittedProgram {
-    /// The exact parsed artifact that passed admission.
+impl super::LoadedProgram {
+    /// The exact parsed artifact used for execution.
     #[must_use]
     pub fn program(&self) -> &Program {
         &self.program

--- a/crates/arena0-sandbox/src/engine/mod.rs
+++ b/crates/arena0-sandbox/src/engine/mod.rs
@@ -19,7 +19,7 @@ use crate::{Program, SandboxError, validation};
 use entropy::Entropy;
 
 const STACK_LIMIT: usize = MAX_WASM_STACK_BYTES;
-const ADMISSION_CACHE_CAPACITY: u64 = 32;
+const PROGRAM_CACHE_CAPACITY: u64 = 32;
 
 /// The export currently being executed. Host imports use this to enforce
 /// capability-specific read/write boundaries in addition to the guest's typed
@@ -246,7 +246,7 @@ impl HostState {
 pub struct WasmtimeEngine {
     pub(crate) engine: Engine,
     pub(crate) profile: ExecutionProfile,
-    pub(crate) admitted: Cache<ProgramHash, Arc<AdmittedProgram>>,
+    pub(crate) loaded: Cache<ProgramHash, Arc<LoadedProgram>>,
     pub(crate) persistent_cache: Option<wasmtime::Cache>,
 }
 
@@ -261,7 +261,7 @@ impl std::fmt::Debug for WasmtimeEngine {
 
 /// Immutable program after metadata, exports, imports, ABI, and module
 /// compilation have all been checked.
-pub struct AdmittedProgram {
+pub struct LoadedProgram {
     pub(crate) engine: Engine,
     pub(crate) module: Module,
     pub(crate) program: Program,
@@ -269,16 +269,16 @@ pub struct AdmittedProgram {
     pub(crate) state_max_bytes: usize,
 }
 
-impl std::fmt::Debug for AdmittedProgram {
+impl std::fmt::Debug for LoadedProgram {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AdmittedProgram")
+        f.debug_struct("LoadedProgram")
             .field("hash", &self.program.hash())
             .field("profile_hash", &self.profile.hash())
             .finish()
     }
 }
 
-impl AdmittedProgram {
+impl LoadedProgram {
     pub(crate) fn validate_shared_state(
         &self,
         shared: &SharedStateBytes,

--- a/crates/arena0-sandbox/src/engine/runtime.rs
+++ b/crates/arena0-sandbox/src/engine/runtime.rs
@@ -1,4 +1,4 @@
-//! Fresh-instance execution operations for admitted programs.
+//! Fresh-instance execution operations for loaded programs.
 
 use arena0_program::{
     CallStatus, InitInput, LocalInput, LocalOutput, OutcomeInput, OutcomeOutput, QueryInput,
@@ -17,7 +17,7 @@ use crate::{
     InitializedState, LocalCallResult, SandboxError, SharedCallResult,
 };
 
-impl super::AdmittedProgram {
+impl super::LoadedProgram {
     /// Execute initialization in a fresh guest instance.
     pub fn initialize(&self, call: InitializeCall) -> Result<InitializedState, SandboxError> {
         let input = call.into_input()?;
@@ -348,7 +348,7 @@ fn ensure_read_only(observations: &CallObservations, operation: &str) -> Result<
     }
 }
 
-impl super::AdmittedProgram {
+impl super::LoadedProgram {
     fn initialized_state(
         &self,
         output: arena0_program::InitializedState,
@@ -387,7 +387,7 @@ mod fresh_runtime_tests {
 
     use super::*;
     use crate::call::{LocalEvent, SharedEvent};
-    use crate::{AdmittedProgram, Program, WasmtimeEngine};
+    use crate::{LoadedProgram, Program, WasmtimeEngine};
     use arena0_program::{
         Capability, JsonBytes, JsonSchemaDocument, LocalStateBytes, ProgramDefinition,
         ProgramMetadata, ProgramSchema, QuerySchema, SharedStateBytes, StateSchema,
@@ -488,7 +488,7 @@ mod fresh_runtime_tests {
         imports: &'a str,
     }
 
-    fn module(spec: ModuleSpec<'_>) -> Arc<AdmittedProgram> {
+    fn module(spec: ModuleSpec<'_>) -> Arc<LoadedProgram> {
         let initialize_data = wat_data(spec.initialize);
         let shared_data = wat_data(spec.shared);
         let shared_second_data = wat_data(spec.shared_second);
@@ -645,7 +645,7 @@ mod fresh_runtime_tests {
         );
         let binary = wat::parse_str(wat).unwrap();
         let program = Program::embed(&binary, &definition).unwrap();
-        WasmtimeEngine::new().unwrap().admit(&program).unwrap()
+        WasmtimeEngine::new().unwrap().load(&program).unwrap()
     }
 
     fn peers() -> (PeerId, Ensemble<Committed>) {

--- a/crates/arena0-sandbox/src/error.rs
+++ b/crates/arena0-sandbox/src/error.rs
@@ -43,7 +43,7 @@ pub enum SandboxError {
     /// The program wrote to the session memory region during a read-only phase.
     #[error("read-only violation: program wrote to state region during {operation}")]
     ReadOnlyViolation { operation: String },
-    /// A Wasm program exceeds the host admission bound.
+    /// A Wasm program exceeds the host program-size bound.
     #[error("program size {size} exceeds the limit of {max} bytes")]
     ProgramTooLarge { size: u64, max: u64 },
     /// A memory allocation would exceed the configured limit.

--- a/crates/arena0-sandbox/src/lib.rs
+++ b/crates/arena0-sandbox/src/lib.rs
@@ -1,9 +1,10 @@
 //! Deterministic Wasm sandbox for fresh, bounded arena0 guest calls.
 //!
-//! Admission compiles immutable Wasm once. Every semantic invocation creates a
-//! fresh Wasmtime store and instance, restores explicit shared and local state
-//! bytes, calls exactly one capability-specific export, collects one atomic
-//! result, and drops the instance. No mutable guest instance crosses this API.
+//! Loading a program compiles its immutable Wasm once per engine.
+//! Every semantic invocation creates a fresh Wasmtime store and instance,
+//! restores explicit shared and local state bytes, calls exactly one
+//! capability-specific export, collects one atomic result, and drops the
+//! instance. No mutable guest instance crosses this API.
 //!
 //! The ABI exports are `arena0_initialize`, `arena0_shared`, `arena0_local`,
 //! `arena0_writer`, `arena0_query`, `arena0_view`, `arena0_outcome`, and
@@ -23,7 +24,7 @@ pub use call::{
     InitializeCall, LocalCall, LocalEvent, OutcomeCall, QueryCall, RandomReplay, RandomReplayError,
     SharedCall, SharedEvent, ViewCall, WriterCall,
 };
-pub use engine::{AdmittedProgram, WasmtimeEngine};
+pub use engine::{LoadedProgram, WasmtimeEngine};
 pub use error::SandboxError;
 
 mod program;

--- a/crates/arena0-sandbox/src/program.rs
+++ b/crates/arena0-sandbox/src/program.rs
@@ -341,7 +341,7 @@ mod tests {
     }
 
     #[test]
-    fn admission_reuses_the_engine_scoped_compiled_program() {
+    fn loading_reuses_the_engine_scoped_compiled_program() {
         let engine = WasmtimeEngine::new().unwrap();
         let program = engine.build_program(&metadata_export_module()).unwrap();
         let output = SharedWriter::default();
@@ -353,8 +353,8 @@ mod tests {
 
         let (first, second) = tracing::subscriber::with_default(subscriber, || {
             (
-                engine.admit(&program).unwrap(),
-                engine.admit(&program).unwrap(),
+                engine.load(&program).unwrap(),
+                engine.load(&program).unwrap(),
             )
         });
 
@@ -402,12 +402,12 @@ mod tests {
         let cache_dir = tempfile::tempdir().unwrap();
 
         let first = WasmtimeEngine::new_persistent(cache_dir.path()).unwrap();
-        first.admit(&program).unwrap();
+        first.load(&program).unwrap();
         assert_eq!(first.persistent_cache.as_ref().unwrap().cache_misses(), 1);
         drop(first);
 
         let second = WasmtimeEngine::new_persistent(cache_dir.path()).unwrap();
-        second.admit(&program).unwrap();
+        second.load(&program).unwrap();
         assert_eq!(second.persistent_cache.as_ref().unwrap().cache_hits(), 1);
     }
 

--- a/crates/arena0-sandbox/src/validation.rs
+++ b/crates/arena0-sandbox/src/validation.rs
@@ -69,8 +69,8 @@ const REQUIRED_GLOBAL_EXPORTS: &[&str] = &["arena0_abi_version"];
 const GLOBAL_POINTER_THRESHOLD: u32 = 65_536;
 
 /// Validate every embedded JSON Schema document before the sandbox accepts
-/// metadata. Schemas are introspection-only; this is admission hygiene, not a
-/// serialization contract.
+/// metadata. Schemas are introspection-only; this validates program metadata,
+/// not a serialization contract.
 pub(crate) fn validate_program_definition(
     definition: &ProgramDefinition,
 ) -> Result<(), SandboxError> {

--- a/crates/arena0-store/src/lib.rs
+++ b/crates/arena0-store/src/lib.rs
@@ -189,9 +189,9 @@ pub enum ProgramStoreOutcome {
 /// Result of unregistering one content-addressed program.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProgramRemoveOutcome {
-    /// New-admission membership was removed; artifact bytes remain durable.
+    /// Active catalog membership was removed; artifact bytes remain durable.
     Removed,
-    /// It was already absent from new-admission membership.
+    /// It was already absent from active catalog membership.
     AlreadyRemoved,
 }
 
@@ -350,7 +350,7 @@ impl ExecutionRequest {
         self.execution_id
     }
 
-    /// Return the admitted program content address.
+    /// Return the requested program content address.
     #[must_use]
     pub const fn program_hash(&self) -> ProgramHash {
         self.program_hash
@@ -1731,8 +1731,8 @@ impl StoreHandle {
         response.await.map_err(|_| StoreError::ReplyDropped)?
     }
 
-    /// Unregister a program from new admission while retaining its bytes for
-    /// existing durable execution recovery.
+    /// Unregister a program from the active catalog while retaining its bytes
+    /// for existing durable execution recovery.
     pub async fn remove_program(
         &self,
         hash: ProgramHash,

--- a/crates/arena0-tests/src/arena.rs
+++ b/crates/arena0-tests/src/arena.rs
@@ -2,7 +2,7 @@
 //!
 //! The harness deliberately follows the public construction boundary: each
 //! participant has a persistent SQLite [`arena0_store::Store`], a Host-issued
-//! execution capability, an admitted immutable Wasm program, and a local
+//! execution capability, a loaded immutable Wasm program, and a local
 //! transport endpoint. There is no mutable sandbox or in-memory store mock in
 //! this test layer.
 use std::fmt::Write as _;
@@ -224,8 +224,8 @@ impl Arena {
         let creator_params = self.params.clone();
         let creator_program = WasmtimeEngine::new()
             .expect("sandbox")
-            .admit(&program)
-            .expect("admit");
+            .load(&program)
+            .expect("load");
         let initialized = creator_program
             .initialize(InitializeCall::new(
                 JsonBytes::try_new(creator_params.clone()).expect("valid creator params"),
@@ -412,11 +412,11 @@ impl Arena {
                 let recompute_initial_state = Box::new(move |params: &[u8]| {
                     let program = Program::try_from(recompute_wasm.clone())
                         .map_err(|error| error.to_string())?;
-                    let admitted = WasmtimeEngine::new()
+                    let loaded = WasmtimeEngine::new()
                         .map_err(|error| error.to_string())?
-                        .admit(&program)
+                        .load(&program)
                         .map_err(|error| error.to_string())?;
-                    let initialized = admitted
+                    let initialized = loaded
                         .initialize(InitializeCall::new(
                             JsonBytes::try_new(params.to_vec())
                                 .map_err(|error| error.to_string())?,
@@ -486,10 +486,10 @@ impl Arena {
             let node = &identities[i];
             let node_params = creator_params.clone();
             let program = Program::try_from(wasm.clone()).expect("program");
-            let admitted = WasmtimeEngine::new()
+            let loaded = WasmtimeEngine::new()
                 .expect("sandbox creation")
-                .admit(&program)
-                .expect("admit program");
+                .load(&program)
+                .expect("load program");
             let exec_id = exec_id_for(i);
             let execution_key = host
                 .execution_key(&execution_salt_for(i), &exec_id, &negotiation_id)
@@ -497,7 +497,7 @@ impl Arena {
             let (node_committed, execution_store) = negotiated.next().expect("committed execution");
             let context = ExecContext::new(
                 exec_id,
-                admitted,
+                loaded,
                 JsonBytes::try_new(node_params.clone()).expect("valid node params"),
                 node_committed.activation().clone(),
                 execution_key,

--- a/crates/arena0-tests/src/fixtures.rs
+++ b/crates/arena0-tests/src/fixtures.rs
@@ -174,12 +174,12 @@ pub async fn spawn_live_execution(
     cryptos.sort_by_key(NodeKeys::peer_id);
     let peer_ids = cryptos.iter().map(NodeKeys::peer_id).collect::<Vec<_>>();
     let program = Program::try_from(wasm.clone()).expect("program");
-    let admitted = WasmtimeEngine::new()
+    let loaded = WasmtimeEngine::new()
         .expect("sandbox engine")
-        .admit(&program)
-        .expect("admit program");
+        .load(&program)
+        .expect("load program");
     let params_json = arena0_program::JsonBytes::try_new(params.clone()).expect("JSON params");
-    let initialized = admitted
+    let initialized = loaded
         .initialize(InitializeCall::new(params_json.clone()))
         .expect("initialize program");
     let initial_state = StateHash::of(initialized.shared.as_bytes());
@@ -248,13 +248,13 @@ pub async fn spawn_live_execution(
         .commit_activation(activation.clone(), 4)
         .await
         .expect("commit activation");
-    let admitted = WasmtimeEngine::new()
+    let loaded = WasmtimeEngine::new()
         .expect("sandbox engine")
-        .admit(&program)
-        .expect("admit program for actor");
+        .load(&program)
+        .expect("load program for actor");
     let context = ExecContext::new(
         exec_id,
-        admitted,
+        loaded,
         params_json,
         activation.clone(),
         execution_key(identity.as_ref()),

--- a/crates/arena0-tests/tests/daemon_e2e.rs
+++ b/crates/arena0-tests/tests/daemon_e2e.rs
@@ -94,7 +94,7 @@ async fn daemon_hosts_play_and_verify() {
 
     // The first callout is observed through both public projections before
     // either driver answers it. The expected metadata comes independently
-    // from the admitted RPS program; the context is the program's documented
+    // from the loaded RPS program; the context is the program's documented
     // first-round request, not a value copied from either projection.
     let next_request = HostRequest::ExecNext {
         exec_id: callout_exec,

--- a/crates/arena0-tests/tests/execution_receive.rs
+++ b/crates/arena0-tests/tests/execution_receive.rs
@@ -1,6 +1,6 @@
 //! Greybox observations over the public Host execution boundary.
 //!
-//! These tests use a real admitted Wasm guest and a real SQLite execution
+//! These tests use a real loaded Wasm guest and a real SQLite execution
 //! store. Peer frames enter through authenticated `LocalTransport` streams;
 //! assertions observe durable traces, inbox projections, and lifecycle
 //! messages rather than a mutable sandbox mock.

--- a/crates/arena0-tests/tests/receipt_recovery.rs
+++ b/crates/arena0-tests/tests/receipt_recovery.rs
@@ -41,9 +41,9 @@ async fn recover_after(cut: CrashAfter) {
         let peers = keys.iter().map(PeerIdSource::peer_id).collect::<Vec<_>>();
         let wasm = ordering_program_wasm(false);
         let program = Program::try_from(wasm.clone()).expect("program");
-        let admitted = WasmtimeEngine::new().unwrap().admit(&program).unwrap();
+        let loaded = WasmtimeEngine::new().unwrap().load(&program).unwrap();
         let params = JsonBytes::try_new(br#"{}"#.to_vec()).unwrap();
-        let initialized = admitted
+        let initialized = loaded
             .initialize(InitializeCall::new(params.clone()))
             .unwrap();
         let exec_id = ExecId([0x73; 32]);
@@ -140,7 +140,7 @@ async fn recover_after(cut: CrashAfter) {
         let writer = host.claim_execution(exec_id).unwrap();
         let context = ExecContext::new(
             exec_id,
-            admitted,
+            loaded,
             params,
             activation,
             execution_key(&identity),

--- a/crates/arena0-tests/tests/store.rs
+++ b/crates/arena0-tests/tests/store.rs
@@ -65,7 +65,7 @@ async fn registry_projection_is_content_addressed_and_durable() {
             .expect("list after remove")
             .is_empty()
     );
-    // Removal only removes new-admission membership. Existing bytes remain
+    // Removal only removes active catalog membership. Existing bytes remain
     // durable for recovery, which is the store's documented projection.
     assert_eq!(
         handle

--- a/crates/arena0-verify/src/error.rs
+++ b/crates/arena0-verify/src/error.rs
@@ -55,7 +55,7 @@ pub enum VerifyError {
         /// Hash committed by the activation.
         attested: ProgramHash,
     },
-    /// The supplied Wasm is over the sandbox's admission bound.
+    /// The supplied Wasm is over the sandbox's program-size bound.
     #[error("program is {actual} bytes; maximum is {max}")]
     ProgramTooLarge { actual: usize, max: u64 },
     /// The replay sandbox rejected a fresh call.

--- a/crates/arena0-verify/src/full.rs
+++ b/crates/arena0-verify/src/full.rs
@@ -8,7 +8,7 @@ use arena0_protocol::{
     StateHash, StopCause, TraceEntry,
 };
 use arena0_sandbox::{
-    AdmittedProgram, InitializeCall, OutcomeCall, Program, SharedCall, SharedEvent, WasmtimeEngine,
+    InitializeCall, LoadedProgram, OutcomeCall, Program, SharedCall, SharedEvent, WasmtimeEngine,
     WriterCall,
 };
 
@@ -121,10 +121,10 @@ fn verify_full_inner(
     let program = Program::try_from(program_binary.to_vec())
         .map_err(|error| VerifyError::Sandbox(error.to_string()))?;
     let engine = WasmtimeEngine::new().map_err(|error| VerifyError::Sandbox(error.to_string()))?;
-    let admitted = engine
-        .admit(&program)
+    let loaded = engine
+        .load(&program)
         .map_err(|error| VerifyError::Sandbox(error.to_string()))?;
-    verify_profile(&admitted, &receipt)?;
+    verify_profile(&loaded, &receipt)?;
 
     let session = Ensemble::<Committed>::from_peers(ensemble).map_err(|error| {
         VerifyError::ReplayMismatch {
@@ -138,7 +138,7 @@ fn verify_full_inner(
             message: format!("activation params are not valid JSON: {error}"),
         }
     })?;
-    let initialized = admitted
+    let initialized = loaded
         .initialize(InitializeCall::new(params))
         .map_err(|error| VerifyError::Sandbox(error.to_string()))?;
     let trace = receipt.body().trace();
@@ -167,11 +167,11 @@ fn verify_full_inner(
     // Re-run the read-only outcome projection against the final explicit shared
     // state only for a completed proof. A stopped proof has no outcome DTO to
     // project; its exact StopCause remains the result evidence.
-    let final_shared = replay_trace(&admitted, &session, initialized.shared, trace)?;
+    let final_shared = replay_trace(&loaded, &session, initialized.shared, trace)?;
     let terminal = match terminal {
         LightVerifiedTerminal::Stopped { cause } => VerifiedTerminal::Stopped { cause },
         LightVerifiedTerminal::Completed { outcome_borsh } => {
-            let outcome = admitted
+            let outcome = loaded
                 .outcome(OutcomeCall::new(final_shared, session))
                 .map_err(|error| VerifyError::Sandbox(error.to_string()))?;
             if outcome.borsh.as_bytes() != outcome_borsh.as_slice() {
@@ -191,10 +191,7 @@ fn verify_full_inner(
     })
 }
 
-fn verify_profile(
-    admitted: &AdmittedProgram,
-    receipt: &ReceiptArtifact,
-) -> Result<(), VerifyError> {
+fn verify_profile(loaded: &LoadedProgram, receipt: &ReceiptArtifact) -> Result<(), VerifyError> {
     let attested = receipt
         .body()
         .header()
@@ -202,7 +199,7 @@ fn verify_profile(
         .offer()
         .data()
         .execution_profile;
-    let replaying = admitted.profile().hash();
+    let replaying = loaded.profile().hash();
     if attested != replaying {
         return Err(VerifyError::FingerprintMismatch {
             attested: attested.to_string(),
@@ -213,19 +210,19 @@ fn verify_profile(
 }
 
 fn replay_trace(
-    admitted: &AdmittedProgram,
+    loaded: &LoadedProgram,
     session: &Ensemble<Committed>,
     mut shared: SharedStateBytes,
     trace: &[TraceEntry],
 ) -> Result<SharedStateBytes, VerifyError> {
     for entry in trace {
-        shared = replay_entry(admitted, session, shared, entry)?;
+        shared = replay_entry(loaded, session, shared, entry)?;
     }
     Ok(shared)
 }
 
 fn replay_entry(
-    admitted: &AdmittedProgram,
+    loaded: &LoadedProgram,
     session: &Ensemble<Committed>,
     shared: SharedStateBytes,
     entry: &TraceEntry,
@@ -249,7 +246,7 @@ fn replay_entry(
             pre_state,
             msg,
         } => {
-            let writer = admitted
+            let writer = loaded
                 .writer(WriterCall::new(shared.clone(), session.clone()))
                 .map_err(|error| VerifyError::Sandbox(error.to_string()))?;
             let sender =
@@ -281,7 +278,7 @@ fn replay_entry(
             )
         }
     };
-    let result = admitted
+    let result = loaded
         .apply_shared(call)
         .map_err(|error| VerifyError::Sandbox(error.to_string()))?;
     if result.status != CallStatus::Accepted {
@@ -366,9 +363,9 @@ mod tests {
 
     /// Build a tiny real guest that accepts two public calls, ends the session
     /// on the second one, and projects a unit outcome. The test drives this
-    /// admitted program to produce its trace rather than hand-writing guest
+    /// loaded program to produce its trace rather than hand-writing guest
     /// outputs, so full verification exercises the actual replay boundary.
-    fn admitted_replay_program() -> (Vec<u8>, Arc<AdmittedProgram>) {
+    fn loaded_replay_program() -> (Vec<u8>, Arc<LoadedProgram>) {
         let unit = JsonSchemaDocument::unit();
         let definition = ProgramDefinition {
             metadata: ProgramMetadata {
@@ -459,11 +456,11 @@ mod tests {
         let program = engine.build_program(&raw).expect("embed metadata");
         let binary = program.bytes().to_vec();
         let parsed = Program::try_from(binary.clone()).expect("parse completed program");
-        let admitted = engine.admit(&parsed).expect("admit fixture");
-        (binary, admitted)
+        let loaded = engine.load(&parsed).expect("load fixture");
+        (binary, loaded)
     }
 
-    fn replay_receipt(admitted: &AdmittedProgram, stopped: bool) -> Vec<u8> {
+    fn replay_receipt(loaded: &LoadedProgram, stopped: bool) -> Vec<u8> {
         let identities = [
             NodeKeys::from_secret(SecretKey::from_bytes([1; 32])),
             NodeKeys::from_secret(SecretKey::from_bytes([2; 32])),
@@ -488,7 +485,7 @@ mod tests {
             .map(|identity| PeerId(identity.ed25519_public_key().0))
             .collect::<Vec<_>>();
         let params = arena0_program::JsonBytes::try_new(br#"null"#.to_vec()).expect("params");
-        let initialized = admitted
+        let initialized = loaded
             .initialize(InitializeCall::new(params.clone()))
             .expect("initialize");
         let initial_state = StateHash::of(initialized.shared.as_bytes());
@@ -496,8 +493,8 @@ mod tests {
             negotiation_id,
             0,
             peers[0],
-            admitted.program().hash(),
-            admitted.profile().hash(),
+            loaded.program().hash(),
+            loaded.profile().hash(),
             params.clone(),
             2,
             initial_state,
@@ -554,7 +551,7 @@ mod tests {
         .expect("activation");
         let ensemble = Ensemble::from_peers(peers.clone()).expect("ensemble");
 
-        let started = admitted
+        let started = loaded
             .apply_shared(SharedCall::session_started(
                 initialized.shared.clone(),
                 ensemble.clone(),
@@ -645,7 +642,7 @@ mod tests {
             pre_state: first_state,
             msg: message.clone(),
         };
-        let writer = admitted
+        let writer = loaded
             .writer(arena0_sandbox::WriterCall::new(
                 started.shared.clone(),
                 ensemble.clone(),
@@ -655,7 +652,7 @@ mod tests {
             writer.writer.map(|participant| participant.index()),
             Some(0)
         );
-        let finished = admitted
+        let finished = loaded
             .apply_shared(SharedCall::new(
                 started.shared,
                 ensemble.clone(),
@@ -758,9 +755,9 @@ mod tests {
     }
 
     #[test]
-    fn replay_accepts_a_receipt_from_an_admitted_program() {
-        let (program, admitted) = admitted_replay_program();
-        let receipt = replay_receipt(&admitted, false);
+    fn replay_accepts_a_receipt_from_a_loaded_program() {
+        let (program, loaded) = loaded_replay_program();
+        let receipt = replay_receipt(&loaded, false);
 
         let verified = verify_full(&program, &receipt).expect("valid replay receipt");
         assert_eq!(verified.steps, 2);
@@ -775,8 +772,8 @@ mod tests {
 
     #[test]
     fn stopped_receipt_still_requires_the_bound_program_and_replays_its_public_prefix() {
-        let (program, admitted) = admitted_replay_program();
-        let receipt = replay_receipt(&admitted, true);
+        let (program, loaded) = loaded_replay_program();
+        let receipt = replay_receipt(&loaded, true);
 
         assert!(matches!(
             verify_full(b"not the bound program", &receipt),
@@ -797,8 +794,8 @@ mod tests {
         use std::io::{self, Write};
         use std::sync::{Arc, Mutex};
 
-        let (program, admitted) = admitted_replay_program();
-        let receipt = replay_receipt(&admitted, false);
+        let (program, loaded) = loaded_replay_program();
+        let receipt = replay_receipt(&loaded, false);
         let output = SharedWriter::default();
         let subscriber = tracing_subscriber::fmt()
             .json()

--- a/crates/arena0-verify/src/lib.rs
+++ b/crates/arena0-verify/src/lib.rs
@@ -4,7 +4,7 @@
 //! complete activation-chain, trace, and certificate checks and
 //! has no sandbox dependency. With the `replay` feature, full verification also
 //! accepts the exact Wasm bytes and replays every public call through fresh
-//! sandbox-admitted guest calls.
+//! sandbox instances loaded from that program.
 
 mod error;
 mod light;

--- a/docs/protocol-architecture.md
+++ b/docs/protocol-architecture.md
@@ -338,7 +338,7 @@ Before recording the execution request, `arena0-node::Host` claims one
 exclusive `ExecutionStore` writer. Its state-changing methods require `&mut
 self`, so the type checker carries that ownership through request persistence
 and negotiation into one private `ExecutionActor` after the activation commit.
-The actor is the only live owner of the admitted guest, execution signer, and
+The actor is the only live owner of the loaded guest, execution signer, and
 transport capabilities for that `ExecId`. API handlers and supervisors send
 commands to the actor or read durable projections; they do not hold a second
 mutable execution object. The Host rejects a second live claim, and dropping
@@ -378,45 +378,49 @@ never defines execution serialization and never participates in commitments,
 receipts, or replay verification. Other program Borsh values, including receipt
 params and outcomes, remain opaque bytes to the Host.
 
-Admission validates every required guest export before import. The canonical
-list of names and signatures is `arena0_sandbox::validation::REQUIRED_FUNC_EXPORTS`, and the ABI remains
+Program import validates every required guest export before the artifact enters
+the Host's program catalog. The canonical list of names and signatures is
+`arena0_sandbox::validation::REQUIRED_FUNC_EXPORTS`, and the ABI remains
 `ABI_VERSION = 20`.
 
 The sandbox boundary has two ownership stages:
 
 ```text
-Program -> AdmittedProgram
+Program -> LoadedProgram
 ```
 
-`Program` is an immutable final Wasm artifact. Construction parses exactly one
-embedded `arena0.metadata` section, validates its public definition, and hashes
-the exact final bytes. Parsing a completed artifact never executes guest code.
+`Program` is an immutable final Wasm artifact. `LoadedProgram` is the loaded,
+compiled representation used for execution. `Program` construction parses
+exactly one embedded `arena0.metadata` section, validates its public definition,
+and hashes the exact final bytes. Parsing a completed artifact never executes
+guest code.
 Only `WasmtimeEngine::build_program` accepts section-less build output: it runs
 the guest metadata export in a disposable fuel- and memory-bounded instance,
 appends the section once, and returns a parsed `Program`.
 
-`WasmtimeEngine::admit` compiles the artifact once per engine and caches the
-immutable admission by `ProgramHash` in a bounded, concurrent cache. The daemon
+`WasmtimeEngine::load` loads, validates, and compiles an artifact for execution.
+It compiles the artifact once per engine and caches the resulting immutable
+`LoadedProgram` by `ProgramHash` in a bounded, concurrent cache. The daemon
 also configures Wasmtime's bounded disk cache below the stable arena0 cache
 directory, so compiled machine code survives process restarts and disposable
 `--tmp` homes while remaining keyed by Wasmtime's compiler configuration.
-Admission validates imports and exact export signatures and uses
-a disposable bounded instance to verify the ABI value before the artifact
-enters the Host's program catalog. `AdmittedProgram` owns the immutable compiled
-module and its execution profile. Each
+Program import also uses this method to validate imports and exact export
+signatures and to verify the ABI value in a disposable bounded instance before
+registering the artifact in the Host's program catalog. `LoadedProgram` owns
+the immutable compiled module and its execution profile. Each
 `initialize`, `apply_shared`, `apply_local`, `writer`, `query`, `view`, or
 `outcome` call creates a fresh bounded Wasm instance, passes explicit state
 bytes, and returns a complete result. No mutable guest instance survives a
 call, and no process-wide instance map exists.
 
-The daemon owns one shared `WasmtimeEngine` for validation and admission, not a
-second program catalog. Each Host must first resolve the hash from its own
-SQLite program catalog. Every execution resolves admission through the shared
-engine cache and uses fresh mutable guest state for each call.
+The daemon owns one shared `WasmtimeEngine` for program validation and execution
+loading, not a second program catalog. Each Host must first resolve the hash from
+its own SQLite program catalog. Every execution loads its imported artifact
+through the shared engine cache and uses fresh mutable guest state for each call.
 
 ## 10. Execution and agreement
 
-After `SessionStarted`, each Host's `ExecutionActor` runs the admitted program.
+After `SessionStarted`, each Host's `ExecutionActor` runs the loaded program.
 The actor loads a durable `ExecutionState` snapshot, makes one guest call in a
 fresh bounded Wasm instance, and submits the resulting protocol input to the
 SQLite store. The store's reducer is the only authority that creates the next
@@ -555,7 +559,8 @@ matching older release. Automatic migration is not provided.
 
 Full verification first performs the light checks, then loads the exact Wasm,
 checks its content hash and execution profile, and replays every public call in
-fresh admitted sandbox instances. It compares every state hash, effect list,
+fresh sandbox instances created from the loaded program. It compares every state
+hash, effect list,
 fuel count, and terminal outcome. A completed result includes both the
 authenticated `outcome_borsh` bytes and the guest-produced JSON outcome. A
 stopped result includes the same exact `StopCause` and no outcome field. The


### PR DESCRIPTION
Program preparation and participant admission currently share admission terminology. Rename the sandbox API to `WasmtimeEngine::load` and `LoadedProgram`, and update callers, diagnostics, telemetry, tests, and documentation. Catalog registration remains `import`; the CLI stage becomes program resolution.

Execution behavior is unchanged. A separate import/load contract remains a future consideration in #7.
