### PR TITLE
refactor: tighten runtime and tooling boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,11 @@ jobs:
   # Steps are ordered fast-fail: formatting and clippy run before the test phase.
   check:
     name: fmt + clippy + test
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    # Main pushes and PRs from repository-trusted authors use the persistent runner.
+    runs-on: >-
+      ${{ (github.event_name == 'push' ||
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))
+          && 'arena0-ficus' || 'ubuntu-26.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -123,10 +127,10 @@ jobs:
             !target/doc
             !target/**/incremental
             !programs/target/**/incremental
-          key: rust-v1-${{ runner.os }}-${{ runner.arch }}-ubuntu24-dev-${{ steps.compiler.outputs.identity }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'rust-toolchain.toml', '**/.cargo/config.toml') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rust-v1-${{ runner.environment }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.compiler.outputs.identity }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'rust-toolchain.toml', '**/.cargo/config.toml') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rust-v1-${{ runner.os }}-${{ runner.arch }}-ubuntu24-dev-${{ steps.compiler.outputs.identity }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'rust-toolchain.toml', '**/.cargo/config.toml') }}-
-            rust-v1-${{ runner.os }}-${{ runner.arch }}-ubuntu24-dev-${{ steps.compiler.outputs.identity }}-
+            rust-v1-${{ runner.environment }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.compiler.outputs.identity }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'rust-toolchain.toml', '**/.cargo/config.toml') }}-
+            rust-v1-${{ runner.environment }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.compiler.outputs.identity }}-
 
       - name: Check and test focused scope
         if: ${{ steps.scope.outputs.scope != 'docs' && steps.scope.outputs.scope != 'full' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   gate:
     name: release gate
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -126,10 +126,10 @@ jobs:
       matrix:
         include:
           - target: darwin-arm64
-            os: blacksmith-6vcpu-macos-15
+            os: macos-14
             release_dir: target/optimized-release
           - target: linux-x64
-            os: blacksmith-2vcpu-ubuntu-2204
+            os: ubuntu-26.04
             release_dir: target/optimized-release
     runs-on: ${{ matrix.os }}
     steps:

--- a/crates/arena0-cli/src/setup.rs
+++ b/crates/arena0-cli/src/setup.rs
@@ -48,6 +48,41 @@ struct PlannedFile {
     state: State,
 }
 
+impl FileSpec {
+    fn plan(self, root: &Path) -> anyhow::Result<PlannedFile> {
+        let path = root.join(self.relative);
+        let existing = read_existing(&path)?;
+        let state = match existing {
+            None => State::Missing,
+            Some(existing) if existing == self.content.as_bytes() => State::Identical,
+            Some(_) => State::Different,
+        };
+        Ok(PlannedFile {
+            spec: self,
+            path,
+            state,
+        })
+    }
+}
+
+impl PlannedFile {
+    fn create_missing(&self) -> io::Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let mut output = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&self.path)?;
+        if let Err(error) = output.write_all(self.spec.content.as_bytes()) {
+            drop(output);
+            let _ = fs::remove_file(&self.path);
+            return Err(error);
+        }
+        output.flush()
+    }
+}
+
 impl Target {
     fn options(&self) -> &Options {
         match self {
@@ -205,19 +240,8 @@ fn make_plan(root: &Path, target: &Target, executable: &str) -> anyhow::Result<V
     target
         .files(executable)?
         .into_iter()
-        .map(|spec| plan_generated(root, spec))
+        .map(|spec| spec.plan(root))
         .collect()
-}
-
-fn plan_generated(root: &Path, spec: FileSpec) -> anyhow::Result<PlannedFile> {
-    let path = root.join(spec.relative);
-    let existing = read_existing(&path)?;
-    let state = match existing {
-        None => State::Missing,
-        Some(existing) if existing == spec.content.as_bytes() => State::Identical,
-        Some(_) => State::Different,
-    };
-    Ok(PlannedFile { spec, path, state })
 }
 
 fn read_existing(path: &Path) -> anyhow::Result<Option<Vec<u8>>> {
@@ -262,45 +286,25 @@ fn apply(plan: &[PlannedFile]) -> anyhow::Result<()> {
     }
 
     let mut applied = 0usize;
-    for file in plan {
-        match file.state {
-            State::Identical => {}
-            State::Different => unreachable!("conflicts were rejected above"),
-            State::Missing => match create_missing(file) {
-                Ok(()) => {
-                    applied += 1;
-                    println!("Created {}", file.spec.relative);
-                }
-                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-                    bail!(
-                        "{} appeared during setup; refusing to overwrite it",
-                        file.path.display()
-                    );
-                }
-                Err(error) => {
-                    return Err(error).with_context(|| format!("create {}", file.path.display()));
-                }
-            },
+    for file in plan.iter().filter(|file| file.state == State::Missing) {
+        match file.create_missing() {
+            Ok(()) => {
+                applied += 1;
+                println!("Created {}", file.spec.relative);
+            }
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                bail!(
+                    "{} appeared during setup; refusing to overwrite it",
+                    file.path.display()
+                );
+            }
+            Err(error) => {
+                return Err(error).with_context(|| format!("create {}", file.path.display()));
+            }
         }
     }
     println!("Setup complete: applied {applied} change(s).");
     Ok(())
-}
-
-fn create_missing(file: &PlannedFile) -> io::Result<()> {
-    if let Some(parent) = file.path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let mut output = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&file.path)?;
-    if let Err(error) = output.write_all(file.spec.content.as_bytes()) {
-        drop(output);
-        let _ = fs::remove_file(&file.path);
-        return Err(error);
-    }
-    output.flush()
 }
 
 #[cfg(test)]

--- a/crates/arena0-node/src/execution/guest.rs
+++ b/crates/arena0-node/src/execution/guest.rs
@@ -201,15 +201,10 @@ impl ExecutionActor {
                 "guest signing request program does not match actor program".into(),
             ));
         }
-        let effect_index = usize::try_from(data.effect_index()).map_err(|_| {
-            ExecError::InvalidState(
-                "guest signing request effect coordinate does not fit host index".into(),
-            )
-        })?;
         let expected_pending_id = arena0_protocol::pending_id(
             self.context.exec_id,
             data.private_sequence(),
-            effect_index,
+            data.effect_index(),
         );
         if pending_id != expected_pending_id {
             return Err(ExecError::InvalidState(
@@ -633,6 +628,12 @@ impl ExecutionActor {
                         PrivateEffect::Callout { .. } | PrivateEffect::Sign { .. }
                     )
                 })
+                .map(|index| {
+                    u32::try_from(index).map_err(|_| {
+                        ExecError::InvalidState("private effect coordinate exceeds u32".into())
+                    })
+                })
+                .transpose()?
                 .and_then(|index| {
                     PendingRecord::from_effects(
                         arena0_protocol::pending_id(self.context.exec_id, sequence, index),

--- a/crates/arena0-protocol/src/execution/delta.rs
+++ b/crates/arena0-protocol/src/execution/delta.rs
@@ -317,6 +317,12 @@ impl PrivateDelta {
 
         let mut pending_count = 0usize;
         for (effect_index, guest_effect) in self.record.effects.iter().enumerate() {
+            let effect_index =
+                u32::try_from(effect_index).map_err(|_| ProtocolError::CollectionTooLarge {
+                    kind: "private effects",
+                    actual: effect_index,
+                    max: super::MAX_PRIVATE_EFFECTS,
+                })?;
             match guest_effect {
                 PrivateEffect::Broadcast { data } => {
                     let message_id = MessageId::derive(
@@ -394,13 +400,7 @@ impl PrivateDelta {
                         state.binding.program_hash(),
                         state.execution_id(),
                         state.private.next_record,
-                        u32::try_from(effect_index).map_err(|_| {
-                            ProtocolError::CollectionTooLarge {
-                                kind: "private effects",
-                                actual: effect_index,
-                                max: super::MAX_PRIVATE_EFFECTS,
-                            }
-                        })?,
+                        effect_index,
                         *scheme,
                         data.clone(),
                     )?;
@@ -474,6 +474,8 @@ fn validate_pending_shape(
                 .iter()
                 .position(|candidate| std::ptr::eq(candidate, effect))
                 .ok_or(ProtocolError::InvalidPendingContinuation)?;
+            let effect_index = u32::try_from(effect_index)
+                .map_err(|_| ProtocolError::InvalidPendingContinuation)?;
             let expected_id = pending_id(execution_id, record.seq, effect_index);
             if pending.id != expected_id {
                 return Err(ProtocolError::InvalidPendingContinuation);
@@ -535,13 +537,13 @@ fn validate_pending_state(
 pub fn pending_id(
     execution_id: crate::ExecId,
     private_sequence: u64,
-    effect_index: usize,
+    effect_index: u32,
 ) -> PendingId {
     let bytes = borsh::to_vec(&(
         b"arena0/pending/v1",
         execution_id,
         private_sequence,
-        effect_index as u32,
+        effect_index,
     ))
     .expect("pending id preimage is serializable");
     let digest = blake3::hash(&bytes);
@@ -555,13 +557,13 @@ pub fn pending_id(
 fn derive_timer_id(
     execution_id: crate::ExecId,
     private_sequence: u64,
-    effect_index: usize,
+    effect_index: u32,
 ) -> TimerId {
     let preimage = borsh::to_vec(&(
         b"arena0/timer-coordinate/v1",
         execution_id,
         private_sequence,
-        u32::try_from(effect_index).expect("bounded private effects fit in u32"),
+        effect_index,
     ))
     .expect("timer coordinate is serializable");
     TimerId::derive(&preimage)

--- a/crates/arena0-protocol/src/execution/status.rs
+++ b/crates/arena0-protocol/src/execution/status.rs
@@ -598,7 +598,7 @@ impl ExecutionStatus {
                         != super::pending_id(
                             execution_id,
                             coordinate.record,
-                            coordinate.effect_index as usize,
+                            coordinate.effect_index,
                         )
                 {
                     return Err(ProtocolError::PendingCoordinateMismatch);

--- a/crates/arena0-sdk-macros/src/attr_local.rs
+++ b/crates/arena0-sdk-macros/src/attr_local.rs
@@ -5,9 +5,9 @@ use syn::{Data, DeriveInput, Error, Fields, Result};
 
 pub(crate) fn expand_arena0_local(mut input: DeriveInput) -> Result<TokenStream2> {
     let ident = &input.ident;
-    let has_borsh_serialize = has_derive(&input, "BorshSerialize");
-    let has_borsh_deserialize = has_derive(&input, "BorshDeserialize");
-    let debug_derived = has_derive(&input, "Debug");
+    let has_borsh_serialize = has_derive(&input, "BorshSerialize")?;
+    let has_borsh_deserialize = has_derive(&input, "BorshDeserialize")?;
+    let debug_derived = has_derive(&input, "Debug")?;
     let fields = match &mut input.data {
         Data::Struct(data) => match &mut data.fields {
             Fields::Named(fields) => fields,
@@ -102,20 +102,22 @@ pub(crate) fn expand_arena0_local(mut input: DeriveInput) -> Result<TokenStream2
     })
 }
 
-fn has_derive(input: &DeriveInput, name: &str) -> bool {
-    input.attrs.iter().any(|attr| {
-        attr.path().is_ident("derive")
-            && attr
-                .parse_args_with(Punctuated::<syn::Path, syn::Token![,]>::parse_terminated)
-                .map(|derives| {
-                    derives.iter().any(|path| {
-                        path.segments
-                            .last()
-                            .is_some_and(|segment| segment.ident == name)
-                    })
-                })
-                .unwrap_or(false)
-    })
+fn has_derive(input: &DeriveInput, name: &str) -> Result<bool> {
+    let mut found = false;
+    for attr in input
+        .attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("derive"))
+    {
+        let derives =
+            attr.parse_args_with(Punctuated::<syn::Path, syn::Token![,]>::parse_terminated)?;
+        found |= derives.iter().any(|path| {
+            path.segments
+                .last()
+                .is_some_and(|segment| segment.ident == name)
+        });
+    }
+    Ok(found)
 }
 
 #[cfg(test)]
@@ -213,5 +215,18 @@ mod tests {
             assert!(expanded.contains(":: arena0 :: borsh :: BorshDeserialize"));
             assert!(expanded.contains("\"[redacted]\""));
         }
+    }
+
+    #[test]
+    fn malformed_derive_input_is_rejected() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[derive(BorshSerialize)]
+            #[derive(Debug = "invalid")]
+            pub struct Local {
+                value: u32,
+            }
+        };
+
+        assert!(expand_arena0_local(input).is_err());
     }
 }


### PR DESCRIPTION
Routes trusted CI jobs to arena0-ficus while keeping untrusted pull requests on GitHub-hosted runners, with cache separation based on native runner metadata.

Also uses bounded u32 pending-effect coordinates end to end, rejects malformed local derive attributes, and colocates setup file operations with their owning types.