### PR TITLE
build: use line tables for release debug information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,8 +131,11 @@ doc-markdown = "allow"
 module-name-repetitions = "allow"
 too-long-first-doc-paragraph = "allow"
 
+# Retain source locations for release backtraces without full variable/type
+# debuginfo. This also applies to optimized-release builds in CI.
+# Override locally with CARGO_PROFILE_RELEASE_DEBUG=2 for full debuginfo.
 [profile.release]
-debug = true
+debug = "line-tables-only"
 
 # Debug builds default to full debuginfo, but the Wasmtime-heavy dev graph can
 # overflow hosted runners. Line tables keep breakpoints and symbolized
@@ -169,7 +172,6 @@ opt-level = 3
 
 [profile.optimized-release]
 inherits = "release"
-debug = false
 lto = true
 debug-assertions = false
 opt-level = 3


### PR DESCRIPTION
Release builds currently emit full debug information, adding compilation time and large artifacts. Use `line-tables-only` to retain source locations for backtraces without full variable/type information, and let the `optimized-release` profile used by CI inherit the setting.

In a local daemon-library compilation, line tables reduced compile time from 12.8s to 9.0s and the library archive from 175 MiB to 72 MiB. These are single-run measurements, excluding dependency builds and final executable linking. The optimized-release profile previously disabled debug information entirely; it now retains line tables as well.
