### PR TITLE
ci: promote verified npm release artifacts

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,0 +1,136 @@
+name: Build release artifacts
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  build:
+    name: build ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: darwin-arm64
+            os: macos-14
+            release_dir: target/optimized-release
+          - target: linux-x64
+            os: ubuntu-26.04
+            release_dir: target/x86_64-unknown-linux-gnu/optimized-release
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # rust-toolchain.toml pins the channel and the wasm32 target the programs
+      # need; the host target is the runner's native one.
+      - name: Install toolchain
+        run: rustup show
+
+      - name: Identify compiler
+        id: compiler
+        shell: bash
+        run: echo "identity=$(rustc -vV | git hash-object --stdin)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Rust cache
+        id: rust-cache
+        continue-on-error: true
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            ~/.cargo/git/db
+            target
+            programs/target
+            !target/doc
+            !target/**/incremental
+            !programs/target/**/incremental
+          key: release-zig0152-zigbuild0223-v1-${{ runner.os }}-${{ runner.arch }}-${{ matrix.os }}-optimized-release-${{ steps.compiler.outputs.identity }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'rust-toolchain.toml', '**/.cargo/config.toml') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            release-zig0152-zigbuild0223-v1-${{ runner.os }}-${{ runner.arch }}-${{ matrix.os }}-optimized-release-${{ steps.compiler.outputs.identity }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'rust-toolchain.toml', '**/.cargo/config.toml') }}-
+            release-zig0152-zigbuild0223-v1-${{ runner.os }}-${{ runner.arch }}-${{ matrix.os }}-optimized-release-${{ steps.compiler.outputs.identity }}-
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      # cargo-arena0 builds the guest Wasm and embeds the metadata section that
+      # the daemon's build script packages into the shipped binary.
+      - name: Build programs (wasm32)
+        if: matrix.target == 'darwin-arm64'
+        run: cd programs && cargo run --manifest-path ../Cargo.toml -p cargo-arena0 -- build
+
+      - name: Build public executables
+        if: matrix.target == 'darwin-arm64'
+        run: cargo build --locked --profile optimized-release \
+          -p arena0-cli -p arena0d -p cargo-arena0
+
+      - name: Install Zig
+        if: matrix.target == 'linux-x64'
+        uses: mlugg/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1
+        with:
+          version: 0.15.2
+
+      - name: Install Linux release tools
+        if: matrix.target == 'linux-x64'
+        uses: taiki-e/install-action@84f5ac3124727fb3d284d4d22ee9ab3654fd09a6 # v2.87.7
+        with:
+          tool: cargo-zigbuild@0.22.3, cargo-audit@0.22.2
+
+      - name: Build Linux executables (glibc 2.35)
+        if: matrix.target == 'linux-x64'
+        run: ./scripts/build-linux-release.sh
+
+      - name: Dependency advisory audit
+        if: matrix.target == 'linux-x64'
+        run: |
+          cargo audit --file Cargo.lock
+          cargo audit --file programs/Cargo.lock
+
+      - name: Stage verified executables
+        run: node scripts/stage-release.mjs "${{ matrix.target }}" "${{ matrix.release_dir }}" "dist/${{ matrix.target }}"
+
+      - name: Pack and dry-run native packages
+        run: |
+          node npm/release.mjs pack dist packed "${{ matrix.target }}"
+          ./scripts/publish-npm.sh packed --dry-run
+
+      - name: Test Linux tarballs on Ubuntu 22.04
+        if: matrix.target == 'linux-x64'
+        run: ./scripts/test-linux-package.sh packed
+
+      # Use these same tarballs for the external SDK journey, including native
+      # macOS execution. Publication later packs from the verified binaries.
+      - name: Test packed release candidate
+        env:
+          ARENA0_NPM_TARBALL_DIR: ${{ github.workspace }}/packed
+        run: ./scripts/test-release-candidate.sh
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: arena0-${{ matrix.target }}
+          path: dist/${{ matrix.target }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Save Rust cache
+        if: ${{ !cancelled() && steps.rust-cache.outputs.cache-primary-key != '' }}
+        continue-on-error: true
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            ~/.cargo/git/db
+            target
+            programs/target
+            !target/doc
+            !target/**/incremental
+            !programs/target/**/incremental
+          key: ${{ steps.rust-cache.outputs.cache-primary-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
+  artifacts:
+    name: verified release artifacts
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: check
+    uses: ./.github/workflows/build-artifacts.yml
+
   # One job, not three. Wasmtime dominates compile time, so the win is
   # building the dependency graph once and reusing the warm target dir across
   # fmt -> clippy -> build -> test. Splitting into parallel jobs would recompile
@@ -87,6 +93,13 @@ jobs:
           BASE_SHA: ${{ steps.scope.outputs.base }}
           HEAD_SHA: ${{ steps.scope.outputs.head }}
         run: git diff --check "$BASE_SHA" "$HEAD_SHA"
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      - name: Test release safety contracts
+        run: node --test npm/release.test.mjs scripts/resolve-release-run.test.mjs
 
       # rust-toolchain.toml is the source of truth: it pins the channel, clippy,
       # rustfmt, and the wasm32 target. `rustup show` installs exactly that set.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,6 @@ on:
     tags: ['v*']
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Must match Cargo.toml and, when selected, the release tag'
-        required: false
-      ci_run_id:
-        description: 'Optional successful main-push CI run for this exact commit'
-        required: false
       publish:
         description: 'Publish Rust crates and npm packages'
         type: boolean
@@ -47,8 +41,6 @@ jobs:
         id: source
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_VERSION: ${{ inputs.version }}
-          CI_RUN_ID: ${{ inputs.ci_run_id }}
         run: node scripts/resolve-release-run.mjs
 
       - name: Download macOS executables

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,315 +1,88 @@
 name: Release
 
-# Build the three public executables for each target, publish the guest-author
-# Rust crates in dependency order, and publish the npm packages: one platform
-# package per target (`@0xff-ai/arena0-<target>`) plus the main `@0xff-ai/arena0`
-# meta-package whose launcher resolves the right one. Triggered by a `v*` tag,
-# or manually (set `publish: true` to actually publish).
+# Promote the exact commit's successful main-push CI artifacts. Manual runs
+# exercise the full npm candidate path without any registry writes by default.
 on:
   push:
     tags: ['v*']
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish; must match Cargo.toml (defaults to tag or workspace)'
+        description: 'Must match Cargo.toml and, when selected, the release tag'
+        required: false
+      ci_run_id:
+        description: 'Optional successful main-push CI run for this exact commit'
         required: false
       publish:
-        description: 'Publish Rust crates and npm packages (otherwise build only)'
+        description: 'Publish Rust crates and npm packages'
         type: boolean
         default: false
 
-env:
-  CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: 0
-  # The gate compiles clippy + doc + tests into one target dir like the CI
-  # check job; keep the dev profile lean enough for the hosted runner disk.
-  CARGO_PROFILE_DEV_DEBUG: line-tables-only
-
 permissions:
   contents: read
+  actions: read
+
+# Never interrupt publication between platform packages and the wrapper.
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
 
 jobs:
-  gate:
-    name: release gate
-    runs-on: ubuntu-26.04
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Install toolchain
-        run: rustup show
-
-      - name: Install verification tools
-        uses: taiki-e/install-action@84f5ac3124727fb3d284d4d22ee9ab3654fd09a6 # v2.87.7
-        with:
-          tool: nextest@0.9.143, cargo-audit@0.22.2
-
-      - name: Identify compiler
-        id: compiler
-        shell: bash
-        run: echo "identity=$(rustc -vV | git hash-object --stdin)" >> "$GITHUB_OUTPUT"
-
-      - name: Restore Rust cache
-        id: rust-cache
-        continue-on-error: true
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry/cache
-            ~/.cargo/registry/index
-            ~/.cargo/git/db
-            target
-            programs/target
-            !target/doc
-            !target/**/incremental
-            !programs/target/**/incremental
-          key: rust-v1-${{ runner.os }}-${{ runner.arch }}-ubuntu24-dev-${{ steps.compiler.outputs.identity }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'rust-toolchain.toml', '**/.cargo/config.toml') }}-${{ github.run_id }}-${{ github.run_attempt }}
-          restore-keys: |
-            rust-v1-${{ runner.os }}-${{ runner.arch }}-ubuntu24-dev-${{ steps.compiler.outputs.identity }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'rust-toolchain.toml', '**/.cargo/config.toml') }}-
-            rust-v1-${{ runner.os }}-${{ runner.arch }}-ubuntu24-dev-${{ steps.compiler.outputs.identity }}-
-
-      - name: Format
-        run: |
-          cargo fmt --all --check
-          cargo fmt --manifest-path programs/Cargo.toml --all --check
-
-      - name: Check dependencies
-        run: |
-          ./scripts/check-deps.sh
-          cargo test --locked -p arena0-sandbox --test engine_version
-
-      # The daemon build script requires all seven metadata-bearing guest Wasm
-      # blobs, including when Clippy builds every workspace target.
-      - name: Build programs (wasm32)
-        run: cd programs && cargo run --manifest-path ../Cargo.toml -p cargo-arena0 -- build
-
-      - name: Clippy
-        run: |
-          cargo clippy --locked --workspace --all-targets
-          cargo clippy --locked --manifest-path programs/Cargo.toml --all-targets
-
-      - name: Dependency advisory audit
-        run: |
-          cargo audit --file Cargo.lock
-          cargo audit --file programs/Cargo.lock
-
-      - name: Documentation
-        env:
-          RUSTDOCFLAGS: -D warnings
-        run: cargo doc --locked --workspace --no-deps --all-features --lib
-
-      - name: Test
-        run: |
-          cargo nextest run --locked --workspace --profile ci
-          cargo test --locked --doc -p arena0-primitives -p arena0-sdk
-          cargo nextest run --locked --manifest-path programs/Cargo.toml --profile ci
-
-      - name: Save Rust cache
-        if: ${{ !cancelled() && steps.rust-cache.outputs.cache-primary-key != '' }}
-        continue-on-error: true
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry/cache
-            ~/.cargo/registry/index
-            ~/.cargo/git/db
-            target
-            programs/target
-            !target/doc
-            !target/**/incremental
-            !programs/target/**/incremental
-          key: ${{ steps.rust-cache.outputs.cache-primary-key }}
-
-  build:
-    name: build ${{ matrix.target }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: darwin-arm64
-            os: macos-14
-            release_dir: target/optimized-release
-          - target: linux-x64
-            os: ubuntu-26.04
-            release_dir: target/optimized-release
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      # rust-toolchain.toml pins the channel and the wasm32 target the programs
-      # need; the host target is the runner's native one.
-      - name: Install toolchain
-        run: rustup show
-
-      - name: Identify compiler
-        id: compiler
-        shell: bash
-        run: echo "identity=$(rustc -vV | git hash-object --stdin)" >> "$GITHUB_OUTPUT"
-
-      - name: Restore Rust cache
-        id: rust-cache
-        continue-on-error: true
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry/cache
-            ~/.cargo/registry/index
-            ~/.cargo/git/db
-            target
-            programs/target
-            !target/doc
-            !target/**/incremental
-            !programs/target/**/incremental
-          key: rust-v1-${{ runner.os }}-${{ runner.arch }}-${{ matrix.os }}-optimized-release-${{ steps.compiler.outputs.identity }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'rust-toolchain.toml', '**/.cargo/config.toml') }}-${{ github.run_id }}-${{ github.run_attempt }}
-          restore-keys: |
-            rust-v1-${{ runner.os }}-${{ runner.arch }}-${{ matrix.os }}-optimized-release-${{ steps.compiler.outputs.identity }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'rust-toolchain.toml', '**/.cargo/config.toml') }}-
-            rust-v1-${{ runner.os }}-${{ runner.arch }}-${{ matrix.os }}-optimized-release-${{ steps.compiler.outputs.identity }}-
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 20
-
-      # cargo-arena0 builds the guest Wasm and embeds the metadata section that
-      # the daemon's build script packages into the shipped binary.
-      - name: Build programs (wasm32)
-        run: cd programs && cargo run --manifest-path ../Cargo.toml -p cargo-arena0 -- build
-
-      - name: Build public executables
-        run: cargo build --locked --profile optimized-release \
-          -p arena0-cli -p arena0d -p cargo-arena0
-
-      - name: Check executable versions
-        run: |
-          "${{ matrix.release_dir }}/arena0" --version
-          "${{ matrix.release_dir }}/arena0d" --version
-          "${{ matrix.release_dir }}/cargo-arena0" --version
-
-      - name: Check Linux compatibility baseline
-        if: matrix.target == 'linux-x64'
-        run: ./scripts/check-linux-artifacts.sh "${{ matrix.release_dir }}"
-
-      - name: Stage executables
-        run: |
-          mkdir -p "dist/${{ matrix.target }}"
-          cp "${{ matrix.release_dir }}/arena0" "dist/${{ matrix.target }}/arena0"
-          cp "${{ matrix.release_dir }}/arena0d" "dist/${{ matrix.target }}/arena0d"
-          cp "${{ matrix.release_dir }}/cargo-arena0" "dist/${{ matrix.target }}/cargo-arena0"
-
-      - name: Checksum executables
-        run: |
-          set -euo pipefail
-          for binary in arena0 arena0d cargo-arena0; do
-            if command -v sha256sum >/dev/null 2>&1; then
-              (cd "dist/${{ matrix.target }}" && sha256sum "$binary" >"${binary}.sha256")
-            else
-              (cd "dist/${{ matrix.target }}" && shasum -a 256 "$binary" >"${binary}.sha256")
-            fi
-          done
-
-      # This runner owns the target-native binaries, so the packed artifact
-      # smoke can execute the installed commands without claiming cross-target
-      # support. The script also exercises the packaged SDK path.
-      - name: Test packed release candidate
-        env:
-          ARENA0_RELEASE_DIR: ${{ github.workspace }}/${{ matrix.release_dir }}
-        run: ./scripts/test-release-candidate.sh
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: arena0-${{ matrix.target }}
-          path: dist/${{ matrix.target }}
-          if-no-files-found: error
-
-      - name: Save Rust cache
-        if: ${{ !cancelled() && steps.rust-cache.outputs.cache-primary-key != '' }}
-        continue-on-error: true
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry/cache
-            ~/.cargo/registry/index
-            ~/.cargo/git/db
-            target
-            programs/target
-            !target/doc
-            !target/**/incremental
-            !programs/target/**/incremental
-          key: ${{ steps.rust-cache.outputs.cache-primary-key }}
-
   publish:
-    name: publish to npm
-    needs: [gate, build]
-    runs-on: ubuntu-latest
+    name: verify and promote artifacts
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
+      actions: read
       id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Resolve trusted CI run and release identity
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          CI_RUN_ID: ${{ inputs.ci_run_id }}
+        run: node scripts/resolve-release-run.mjs
 
       - name: Download macOS executables
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: arena0-darwin-arm64
           path: dist/darwin-arm64
+          run-id: ${{ steps.source.outputs.run_id }}
+          github-token: ${{ github.token }}
 
       - name: Download Linux executables
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: arena0-linux-x64
           path: dist/linux-x64
+          run-id: ${{ steps.source.outputs.run_id }}
+          github-token: ${{ github.token }}
 
-      # upload-artifact stores files in ZIP archives and does not preserve
-      # executable mode bits across the download boundary.
-      - name: Restore executable permissions
-        run: chmod +x dist/{darwin-arm64,linux-x64}/{arena0,arena0d,cargo-arena0}
+      - name: Verify identities and checksums, then pack once
+        run: node npm/release.mjs pack dist packed
 
-      - name: Resolve version
-        id: ver
-        run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-          elif [ "$GITHUB_REF_TYPE" = "tag" ]; then
-            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-          else
-            version=$(node -p "require('./npm/arena0/package.json').version")
-            echo "version=$version" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Dry-run exact tarballs
+        run: ./scripts/publish-npm.sh packed --dry-run
 
-      - name: Verify checksums and versions
-        run: |
-          set -euo pipefail
-          for target in darwin-arm64 linux-x64; do
-            for binary in arena0 arena0d cargo-arena0; do
-              test -f "dist/${target}/${binary}"
-              (cd "dist/${target}" && shasum -a 256 -c "${binary}.sha256")
-            done
-          done
-          # The publish runner is Linux x64; execute only that target's
-          # binaries. The macOS artifact is checked by checksum and by its
-          # target-native build job above.
-          for binary in arena0 arena0d cargo-arena0; do
-            actual="$("./dist/linux-x64/${binary}" --version)"
-            expected="${binary} ${{ steps.ver.outputs.version }}"
-            test "$actual" = "$expected" || {
-              echo "version mismatch: expected '$expected', got '$actual'" >&2
-              exit 1
-            }
-          done
+      - name: Test exact Linux tarballs on Ubuntu 22.04
+        run: ./scripts/test-linux-package.sh packed
 
-      - name: Assemble platform packages
-        run: |
-          node npm/assemble.mjs darwin-arm64 dist/darwin-arm64 "${{ steps.ver.outputs.version }}"
-          node npm/assemble.mjs linux-x64    dist/linux-x64    "${{ steps.ver.outputs.version }}"
-
-      - name: Inspect package contents
-        run: |
-          npm pack --dry-run ./npm/arena0-darwin-arm64
-          npm pack --dry-run ./npm/arena0-linux-x64
-          npm pack --dry-run ./npm/arena0
+      - name: Retain candidate tarballs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: arena0-npm-${{ steps.source.outputs.version }}
+          path: packed
+          if-no-files-found: error
+          retention-days: 90
 
       - name: Verify publication credentials
         if: github.event_name == 'push' || inputs.publish
@@ -324,21 +97,20 @@ jobs:
       - name: Publish Rust guest SDK
         if: github.event_name == 'push' || inputs.publish
         env:
-          ARENA0_RELEASE_VERSION: ${{ steps.ver.outputs.version }}
+          ARENA0_RELEASE_VERSION: ${{ steps.source.outputs.version }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: ./scripts/publish-crates.sh
+        run: |
+          rustup show
+          ./scripts/publish-crates.sh
 
       - name: Verify published guest SDK
         if: github.event_name == 'push' || inputs.publish
         env:
           ARENA0_CARGO_BIN: ${{ github.workspace }}/dist/linux-x64/cargo-arena0
-        run: |
-          rustup show
-          ./scripts/test-registry-example.sh
+        run: ./scripts/test-registry-example.sh
 
-      - name: Publish
+      - name: Publish exact tarballs (platforms before wrapper)
         if: github.event_name == 'push' || inputs.publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          ARENA0_RELEASE_VERSION: ${{ steps.ver.outputs.version }}
-        run: ./scripts/publish-npm.sh
+        run: ./scripts/publish-npm.sh packed --publish

--- a/justfile
+++ b/justfile
@@ -13,10 +13,14 @@ build: build-programs
 build-release: build-programs
     cargo build --profile optimized-release -p arena0-cli -p arena0d -p cargo-arena0
 
+# Portable Linux artifacts from any supported Linux x64 build host.
+build-linux-release:
+    ./scripts/build-linux-release.sh
+
 # Run host and program tests (programs wasm first so integration tests do not skip).
 # The doctest line covers the crate doc-tests (incl. the arena0-sdk compile_fail
 # doctest), which `cargo nextest run` does not run by default.
-test: build-programs
+test: build-programs test-release-scripts
     cargo nextest run --workspace
     cargo test --doc -p arena0-primitives -p arena0-sdk
     cargo nextest run --manifest-path programs/Cargo.toml
@@ -89,11 +93,17 @@ npm-smoke target directory:
     node npm/assemble.mjs {{target}} {{directory}}
     ./scripts/test-npm-package.sh {{target}}
 
-# Assemble the host (darwin-arm64) platform package and `npm pack` the main package locally.
-npm-pack-local: build-release
-    node npm/assemble.mjs darwin-arm64 target/optimized-release
-    cd npm/arena0-darwin-arm64 && npm pack --dry-run
-    cd npm/arena0 && npm pack --dry-run
+# Stage, pack, dry-run publication, and test installed binaries; never publishes.
+# Build Linux with `just build-linux-release`, macOS with `just build-release`.
+npm-dry-run directory:
+    ./scripts/npm-dry-run.sh {{quote(directory)}}
+
+# Retained alias; pass the native binary directory explicitly.
+npm-pack-local directory:
+    ./scripts/npm-dry-run.sh {{quote(directory)}}
+
+test-release-scripts:
+    node --test npm/release.test.mjs scripts/resolve-release-run.test.mjs
 
 # Package the public guest-author crates, then test and build the copyable
 # example outside the repository using only the resulting package sources.

--- a/npm/README.md
+++ b/npm/README.md
@@ -30,14 +30,13 @@ the embedded skill, and a replay-verified interaction between two participants.
 The [Release workflow](../.github/workflows/release.yml) promotes artifacts;
 it does not rebuild the public executables. It requires a successful
 `ci.yml` run triggered by a `main` push in this repository at the exact
-checked-out commit. A supplied `ci_run_id` must meet the same conditions.
-There is no fallback to another commit.
+checked-out commit. There is no fallback to another commit.
 
-Push a `v<VERSION>` tag only after that commit's CI run succeeds. The tag and
-an optional manual `version` input must match `Cargo.toml`. A tag that arrives
-before CI finishes fails selection; rerun Release at the same tag once CI
-passes. Artifacts are retained for 90 days. Expired or missing artifacts require
-a new successful CI run for that exact commit.
+Push a `v<VERSION>` tag only after that commit's CI run succeeds. The tag must
+match `Cargo.toml`. A tag that arrives before CI finishes fails selection;
+rerun Release at the same tag once CI passes. Artifacts are retained for 90
+days. Expired or missing artifacts require a new successful CI run for that
+exact commit.
 
 Release requires both platform manifests and every binary checksum. It packs
 the packages once, records tarball SHA-512 integrity, dry-runs publication,

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,46 +1,111 @@
 # npm distribution
 
-`arena0` ships to npm as a meta-package plus one prebuilt-binary package per
-platform, the same shape esbuild and swc use.
+arena0 ships as a wrapper package and two prebuilt-binary packages.
 
-- **`arena0/`** is `@0xff-ai/arena0`, the package users install. Its three
-  launchers resolve the platform package whose `os`/`cpu` match the machine and
-  execute `arena0`, `arena0d`, or `cargo-arena0`, forwarding argv and stdio.
-  The platform packages are `optionalDependencies`, so npm downloads only the
-  one that matches.
-- **`arena0-darwin-arm64/`**, **`arena0-linux-x64/`** are the platform packages
-  (`@0xff-ai/arena0-<target>`). Each ships all three executables, constrained by
-  `os` and `cpu`. The binaries are gitignored; the release workflow drops them in.
+- `arena0/` is `@0xff-ai/arena0`, the package users install. Its launchers
+  resolve the matching platform package and execute `arena0`, `arena0d`, or
+  `cargo-arena0`, forwarding arguments and standard input/output. Exact-version
+  optional dependencies select the platform package.
+- `arena0-darwin-arm64/` and `arena0-linux-x64/` each ship all three
+  executables, constrained by `os` and `cpu`. Generated binaries stay ignored.
 
-The daemon uses unix domain sockets, so Windows is out of scope.
+The daemon uses Unix domain sockets. Windows is not supported.
 
-## Publishing
+## Build and promotion
 
-The [`Release` workflow](../.github/workflows/release.yml) is the supported path:
-push a `v*` tag and it builds the binary for each target (programs wasm first; the
-`arena0` build fails if any program wasm is missing, so the embed can't be empty),
-assembles the platform packages, checks each tarball, and publishes all three
-packages with npm provenance. Before npm publication it publishes the seven
-guest-author Rust crates in dependency order and proves the minimal program
-against crates.io. It needs both the `CARGO_REGISTRY_TOKEN` and `NPM_TOKEN`
-secrets. The tag, Cargo workspace, and npm package versions must match. A manual
-run (`workflow_dispatch`) builds without publishing unless `publish: true`.
+The [CI workflow](../.github/workflows/ci.yml) builds release artifacts after
+its checks pass on a push to `main`. The
+[artifact workflow](../.github/workflows/build-artifacts.yml) builds guests
+before the public executables, checks executable versions, records SHA-256
+checksums and the source commit, and exercises the installed npm toolchain
+with an external program built from the packaged Rust SDK.
+
+macOS builds run natively on Apple silicon. Linux builds use Zig 0.15.2 and
+cargo-zigbuild 0.22.3 with the explicit target
+`x86_64-unknown-linux-gnu.2.35`. The build host does not set the minimum glibc
+version. Linux artifacts must pass both the symbol-version check and an
+Ubuntu 22.04 container test: offline tarball installation, all three commands,
+the embedded skill, and a replay-verified interaction between two participants.
+
+The [Release workflow](../.github/workflows/release.yml) promotes artifacts;
+it does not rebuild the public executables. It requires a successful
+`ci.yml` run triggered by a `main` push in this repository at the exact
+checked-out commit. A supplied `ci_run_id` must meet the same conditions.
+There is no fallback to another commit.
+
+Push a `v<VERSION>` tag only after that commit's CI run succeeds. The tag and
+an optional manual `version` input must match `Cargo.toml`. A tag that arrives
+before CI finishes fails selection; rerun Release at the same tag once CI
+passes. Artifacts are retained for 90 days. Expired or missing artifacts require
+a new successful CI run for that exact commit.
+
+Release requires both platform manifests and every binary checksum. It packs
+the packages once, records tarball SHA-512 integrity, dry-runs publication,
+and tests the resulting Linux tarballs on Ubuntu 22.04. It retains those
+candidate tarballs even for manual dry runs. Actual npm publication consumes
+those same files, with both platform packages before the wrapper.
+
+A manual run defaults to `publish: false` and makes no registry writes.
+A tag push or explicit `publish: true` publishes the seven guest-author Rust
+crates in dependency order, tests the example against crates.io, then publishes
+npm packages with provenance. Publication requires `CARGO_REGISTRY_TOKEN`
+and `NPM_TOKEN`. Each npm name/version is checked before the first npm write:
+an identical existing tarball is skipped on retry; different bytes or a failed
+lookup stop publication. Publication across registries is not atomic.
 
 ## Local dry run
 
+On Linux x64, install the pinned Zig compiler and cargo-zigbuild, then run:
+
 ```bash
-just build-release
-just npm-smoke darwin-arm64 target/optimized-release # on Apple silicon macOS
-just npm-smoke linux-x64 target/optimized-release    # on Ubuntu 22.04
+cargo install --locked --version 0.22.3 cargo-zigbuild
+just build-linux-release
+just npm-dry-run target/x86_64-unknown-linux-gnu/optimized-release
 ```
 
-The Linux assembler rejects binaries requiring newer than glibc 2.35. The
-release workflow builds that artifact on Ubuntu 22.04; a newer Linux host can
-run the Rust release build but cannot package it as the published Linux target.
+The Linux smoke test requires Docker. It may download its container image and
+build dependencies; package installation and execution inside the container
+have no network access. The build preserves the configured Rust compiler
+wrapper and flags.
 
-`assemble.mjs <target> <binary-directory> [version]` copies the three executables
-into the platform package and syncs the version across all three `package.json`
-files (defaulting to the workspace version in `Cargo.toml`), including the main package's
-`optionalDependencies` pins. It also copies arena0's two license files into every
-package. `npm-smoke` installs the packed platform and meta packages into an empty
-prefix and runs all three commands.
+On Apple silicon macOS:
+
+```bash
+just build-release
+just npm-dry-run target/optimized-release
+```
+
+The dry run checks native executable versions and checksums, stages package
+sources outside the checkout, inspects packed contents, runs `npm publish
+--dry-run` on the tarballs, installs them into an empty prefix, and executes
+the smoke test. It prints the retained artifact directory. No registry
+credentials are required and no packages are published.
+
+A local candidate contains only the native platform and the wrapper. Dirty
+tracked source is recorded and permitted for a dry run. Publication requires
+both supported platforms, clean artifact manifests, and a clean tracked
+checkout. These local checks do not establish CI provenance; the Release
+workflow owns that selection.
+
+To exercise the external SDK example with those same tarballs:
+
+```bash
+ARENA0_NPM_TARBALL_DIR=/path/printed/by/dry-run/packed scripts/test-release-candidate.sh
+just test-release-scripts
+```
+
+## Script interfaces
+
+`assemble.mjs <target> <binary-directory> [version] [output-directory]` copies
+the executables, license files, wrapper launchers, and minimal program example.
+It synchronizes package versions and optional-dependency pins. Without an
+output directory it writes into this npm tree; release packing always supplies
+a temporary staging directory.
+
+`node npm/release.mjs pack <artifacts> <new-output-directory> [target]` verifies
+artifact identities and hashes before assembly. Omitting the target requires
+both platforms. The output directory must not exist.
+
+`scripts/publish-npm.sh <packed-directory> [--dry-run|--publish]` verifies the
+packed manifest and tarball integrity before invoking npm. The default is
+`--dry-run`. It never assembles or repacks a package.

--- a/npm/assemble.mjs
+++ b/npm/assemble.mjs
@@ -2,15 +2,17 @@
 // Assemble an arena0 platform package from the built public executables, and sync versions
 // across the main + platform package.json files.
 //
-//   node npm/assemble.mjs <target> <binary-directory> [version]
+//   node npm/assemble.mjs <target> <binary-directory> [version] [output-directory]
 //
 //   target       one of: darwin-arm64, linux-x64
 //   binary-directory  directory containing `arena0`, `arena0d`, and `cargo-arena0`
 //   version      optional; defaults to the workspace version in Cargo.toml
+//   output-directory  optional staging tree; defaults to this npm directory
 //
-// The release workflow runs this once per target; locally it lets you `npm pack`
-// or publish without CI. Versions propagate to the main package's
-// optionalDependencies so the pins always match.
+// release.mjs invokes this for each verified target in a temporary staging tree.
+// Versions propagate to the main package's optionalDependencies so the pins
+// always match. This script only assembles files; it does not verify provenance
+// or publish packages.
 import {
   chmodSync,
   copyFileSync,
@@ -27,12 +29,13 @@ import { fileURLToPath } from 'node:url';
 
 const TARGETS = new Set(['darwin-arm64', 'linux-x64']);
 const BINARIES = ['arena0', 'arena0d', 'cargo-arena0'];
-const npmDir = dirname(fileURLToPath(import.meta.url));
-const repoRoot = resolve(npmDir, '..');
+const sourceNpmDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(sourceNpmDir, '..');
 
-const [target, binaryDirectory, versionArg] = process.argv.slice(2);
+const [target, binaryDirectory, versionArg, outputDirectory] = process.argv.slice(2);
+const npmDir = outputDirectory ? resolve(outputDirectory) : sourceNpmDir;
 if (!target || !binaryDirectory) {
-  console.error('usage: node npm/assemble.mjs <target> <binary-directory> [version]');
+  console.error('usage: node npm/assemble.mjs <target> <binary-directory> [version] [output-directory]');
   process.exit(2);
 }
 if (!TARGETS.has(target)) {
@@ -68,6 +71,20 @@ if (target === 'linux-x64') {
   }
 }
 const binDir = join(npmDir, `arena0-${target}`, 'bin');
+// Release packing uses a separate staging tree. Copy authored package inputs
+// only; ignored binaries or tarballs from a previous local build must not leak in.
+if (npmDir !== sourceNpmDir) {
+  for (const packageDir of ['arena0', 'arena0-darwin-arm64', 'arena0-linux-x64']) {
+    mkdirSync(join(npmDir, packageDir), { recursive: true });
+    for (const file of ['package.json', 'README.md']) {
+      copyFileSync(join(sourceNpmDir, packageDir, file), join(npmDir, packageDir, file));
+    }
+  }
+  mkdirSync(join(npmDir, 'arena0', 'bin'), { recursive: true });
+  for (const file of ['arena0.js', 'arena0d.js', 'cargo-arena0.js', 'launch.js']) {
+    copyFileSync(join(sourceNpmDir, 'arena0', 'bin', file), join(npmDir, 'arena0', 'bin', file));
+  }
+}
 mkdirSync(binDir, { recursive: true });
 for (const binary of BINARIES) {
   const source = join(sourceDir, binary);

--- a/npm/release.mjs
+++ b/npm/release.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// Build artifacts are packed once; publication consumes those exact tarballs.
+import { createHash } from 'node:crypto';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const platforms = ['darwin-arm64', 'linux-x64'];
+const binaries = ['arena0', 'arena0d', 'cargo-arena0'];
+const json = path => JSON.parse(readFileSync(path, 'utf8'));
+const digest = (file, algorithm, encoding = 'hex') => createHash(algorithm).update(readFileSync(file)).digest(encoding);
+const workspaceVersion = () => readFileSync(join(root, 'Cargo.toml'), 'utf8').match(/\[workspace.package\][\s\S]*?version\s*=\s*"([^"]+)"/)[1];
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { cwd: root, encoding: 'utf8', maxBuffer: 16 * 1024 * 1024, ...options });
+  if (result.error || result.status !== 0) throw new Error(result.error?.message ?? `${command}: ${result.stderr}`);
+  if (result.stderr) process.stderr.write(result.stderr);
+  return result.stdout;
+}
+
+function verifyArtifacts(directory, selected, revision, version) {
+  let dirty = false;
+  for (const platform of selected) {
+    const folder = join(directory, platform);
+    const manifest = json(join(folder, 'manifest.json'));
+    if (manifest.platform !== platform || manifest.revision !== revision || manifest.version !== version || typeof manifest.dirty !== 'boolean') {
+      throw new Error(`${platform}: artifact identity does not match ${revision} / ${version}`);
+    }
+    dirty ||= manifest.dirty;
+    for (const binary of binaries) {
+      const file = join(folder, binary);
+      if (digest(file, 'sha256') !== manifest.binaries?.[binary]) throw new Error(`${platform}/${binary}: checksum mismatch`);
+      chmodSync(file, 0o755); // ZIP artifact downloads lose executable permissions.
+    }
+  }
+  return dirty;
+}
+
+function pack(artifactDirectory, outputDirectory, platform) {
+  if (!artifactDirectory || !outputDirectory || (platform && !platforms.includes(platform))) {
+    throw new Error('Usage: node npm/release.mjs pack <artifacts> <new-output-directory> [linux-x64|darwin-arm64]');
+  }
+  const selected = platform ? [platform] : platforms;
+  const revision = run('git', ['rev-parse', 'HEAD']).trim();
+  const version = workspaceVersion();
+  const artifactDirty = verifyArtifacts(resolve(artifactDirectory), selected, revision, version);
+  const dirty = artifactDirty || run('git', ['status', '--porcelain', '--untracked-files=no']).trim() !== '';
+  const output = resolve(outputDirectory);
+  if (existsSync(output)) throw new Error(`Output already exists: ${output}; choose a new directory to preserve packed artifacts.`);
+  mkdirSync(output, { recursive: true });
+  const staging = mkdtempSync(join(tmpdir(), 'arena0-npm-stage-'));
+  const packages = [];
+  try {
+    for (const target of selected) {
+      process.stdout.write(run(process.execPath, [join(root, 'npm/assemble.mjs'), target, resolve(artifactDirectory, target), version, staging]));
+    }
+    for (const packageName of [...selected.map(target => `arena0-${target}`), 'arena0']) {
+      const [packed] = JSON.parse(run('npm', ['pack', '--ignore-scripts', '--json', '--pack-destination', output, join(staging, packageName)]));
+      const expectedFiles = packageName === 'arena0'
+        ? ['bin/arena0.js', 'bin/arena0d.js', 'bin/cargo-arena0.js', 'bin/launch.js', 'examples/minimal-program/Cargo.toml', 'examples/minimal-program/src/lib.rs', 'examples/minimal-program/README.md', 'examples/minimal-program/rust-toolchain.toml']
+        : binaries.map(binary => `bin/${binary}`);
+      expectedFiles.push('package.json', 'README.md', 'LICENSE-APACHE', 'LICENSE-MIT');
+      for (const file of expectedFiles) {
+        const entry = packed.files.find(entry => entry.path === file);
+        if (!entry || entry.size === 0) throw new Error(`${packed.name}: missing or empty ${file}`);
+        if (packageName !== 'arena0' && file.startsWith('bin/') && !(entry.mode & 0o111)) throw new Error(`${packed.name}: ${file} is not executable`);
+      }
+      if (packed.version !== version) throw new Error(`${packed.name}: wrong package version`);
+      const integrity = `sha512-${digest(join(output, packed.filename), 'sha512', 'base64')}`;
+      if (integrity !== packed.integrity) throw new Error(`${packed.name}: tarball integrity mismatch`);
+      packages.push({ name: packed.name, filename: packed.filename, integrity });
+      console.log(`Packed ${packed.name}@${version}: ${packed.size} bytes`);
+    }
+    writeFileSync(join(output, 'manifest.json'), JSON.stringify({ revision, version, dirty, platforms: selected, packages }, null, 2) + '\n');
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+  }
+  console.log(`Packed release: ${output}`);
+}
+
+function publish(directory, mode = '--dry-run') {
+  if (!directory || !['--publish', '--dry-run'].includes(mode)) throw new Error('Usage: node npm/release.mjs publish <packed-directory> [--dry-run|--publish]');
+  const output = resolve(directory);
+  const manifest = json(join(output, 'manifest.json'));
+  const revision = run('git', ['rev-parse', 'HEAD']).trim();
+  if (manifest.revision !== revision || manifest.version !== workspaceVersion()) throw new Error('Packed release does not match this checkout.');
+  if (!Array.isArray(manifest.platforms) || manifest.platforms.length === 0 || new Set(manifest.platforms).size !== manifest.platforms.length || manifest.platforms.some(platform => !platforms.includes(platform))) throw new Error('Invalid packed platform set.');
+  const expectedNames = [...platforms.filter(platform => manifest.platforms.includes(platform)).map(platform => `@0xff-ai/arena0-${platform}`), '@0xff-ai/arena0'];
+  if (JSON.stringify(manifest.packages?.map(pkg => pkg.name)) !== JSON.stringify(expectedNames)) throw new Error('Invalid package set or publication order.');
+  const dryRun = mode === '--dry-run';
+  if (!dryRun && (manifest.dirty !== false || manifest.platforms.length !== platforms.length)) throw new Error('Publication requires clean, verified artifacts for every supported platform.');
+  if (!dryRun && run('git', ['status', '--porcelain', '--untracked-files=no']).trim()) throw new Error('Publication requires a clean checkout.');
+  const packages = manifest.packages.map(pkg => {
+    if (basename(pkg.filename) !== pkg.filename || !pkg.filename.endsWith('.tgz')) throw new Error('Invalid tarball filename.');
+    const file = join(output, pkg.filename);
+    if (`sha512-${digest(file, 'sha512', 'base64')}` !== pkg.integrity) throw new Error(`${pkg.name}: packed tarball changed after validation`);
+    return { ...pkg, file };
+  });
+  // Preflight every immutable name/version before the first registry write.
+  // A retry may skip identical uploads, never a different existing tarball.
+  const existing = new Set();
+  if (!dryRun) {
+    for (const pkg of packages) {
+      const result = spawnSync('npm', ['view', `${pkg.name}@${manifest.version}`, 'dist.integrity', '--json', '--registry=https://registry.npmjs.org'], { encoding: 'utf8' });
+      if (result.error) throw result.error;
+      if (result.status === 0) {
+        if (JSON.parse(result.stdout) !== pkg.integrity) throw new Error(`${pkg.name}@${manifest.version} already exists with different bytes.`);
+        existing.add(pkg.name);
+      } else {
+        let error;
+        try { error = JSON.parse(result.stdout).error; } catch {}
+        if (error?.code !== 'E404') throw new Error(`Cannot check ${pkg.name}: ${result.stderr}`);
+      }
+    }
+  }
+  const tag = manifest.version.includes('-') ? 'dev' : 'latest';
+  for (const pkg of packages) {
+    if (existing.has(pkg.name)) { console.log(`${pkg.name} already published with matching integrity`); continue; }
+    const args = ['publish', pkg.file, '--ignore-scripts', '--access', 'public', '--provenance', '--tag', tag, '--registry=https://registry.npmjs.org'];
+    if (dryRun) args.push('--dry-run');
+    process.stdout.write(run('npm', args));
+  }
+  console.log(dryRun ? 'Dry run complete; no packages published.' : 'Release published.');
+}
+
+try {
+  const [command, ...args] = process.argv.slice(2);
+  if (command === 'pack' && args.length <= 3) pack(...args);
+  else if (command === 'publish' && args.length <= 2) publish(...args);
+  else throw new Error('Usage: node npm/release.mjs <pack|publish> ...');
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+}

--- a/npm/release.test.mjs
+++ b/npm/release.test.mjs
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+function fixture(t) {
+  const root = mkdtempSync(join(tmpdir(), 'arena0-release-test-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  for (const dir of ['npm', 'bin', 'packed']) mkdirSync(join(root, dir));
+  copyFileSync(new URL('./release.mjs', import.meta.url), join(root, 'npm/release.mjs'));
+  writeFileSync(join(root, 'Cargo.toml'), '[workspace.package]\nversion = "1.2.3"\n');
+  for (const args of [['init', '-q'], ['add', '.'], ['-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '-qm', 'fixture']]) {
+    assert.equal(spawnSync('git', args, { cwd: root }).status, 0);
+  }
+  const revision = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).stdout.trim();
+  const manifest = { revision, version: '1.2.3', dirty: false, platforms: ['darwin-arm64', 'linux-x64'], packages: [] };
+  for (const suffix of ['-darwin-arm64', '-linux-x64', '']) {
+    const filename = `arena0${suffix}.tgz`;
+    const bytes = `test package ${suffix}`;
+    writeFileSync(join(root, 'packed', filename), bytes);
+    manifest.packages.push({ name: `@0xff-ai/arena0${suffix}`, filename,
+      integrity: `sha512-${createHash('sha512').update(bytes).digest('base64')}` });
+  }
+  // All registry commands in this suite hit this executable, never npm.
+  writeFileSync(join(root, 'bin/npm'), `#!${process.execPath}\nconst fs = require('node:fs');
+    const args = process.argv.slice(2);
+    fs.appendFileSync(process.env.CALL_LOG, JSON.stringify(args) + '\\n');
+    if (args[0] === 'view') {
+      const responses = JSON.parse(process.env.VIEW_RESPONSES || '{}');
+      const response = responses[args[1]];
+      if (response?.integrity) console.log(JSON.stringify(response.integrity));
+      else { console.log(JSON.stringify({ error: { code: response?.error || 'E404' } })); process.exitCode = 1; }
+    }
+  `, { mode: 0o755 });
+  return {
+    root, manifest,
+    save() { writeFileSync(join(root, 'packed/manifest.json'), JSON.stringify(manifest)); },
+    run(args = ['publish', join(root, 'packed')], env = {}) {
+      return spawnSync(process.execPath, [join(root, 'npm/release.mjs'), ...args], { encoding: 'utf8',
+        env: { ...process.env, PATH: `${root}/bin:${process.env.PATH}`, CALL_LOG: join(root, 'calls.jsonl'), VIEW_RESPONSES: '{}', ...env } });
+    },
+    calls() { return existsSync(join(root, 'calls.jsonl')) ? readFileSync(join(root, 'calls.jsonl'), 'utf8').trim().split('\n').map(JSON.parse) : []; },
+  };
+}
+
+test('default publication mode dry-runs the exact tarballs, platforms before wrapper', t => {
+  const f = fixture(t); f.save();
+  const result = f.run();
+  assert.equal(result.status, 0, result.stderr);
+  const calls = f.calls();
+  assert.equal(calls.length, 3);
+  for (const [index, args] of calls.entries()) {
+    assert.equal(args[0], 'publish');
+    assert.equal(args[1], join(f.root, 'packed', f.manifest.packages[index].filename));
+    assert.ok(args.includes('--dry-run'));
+    assert.ok(args.includes('--ignore-scripts'));
+  }
+});
+
+test('publication preflights all packages, then uploads each exact tarball in order', t => {
+  const f = fixture(t); f.save();
+  const result = f.run(['publish', join(f.root, 'packed'), '--publish']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(f.calls().map(args => args[0]), ['view', 'view', 'view', 'publish', 'publish', 'publish']);
+  assert.deepEqual(f.calls().slice(3).map(args => args[1]), f.manifest.packages.map(pkg => join(f.root, 'packed', pkg.filename)));
+  assert.ok(f.calls().slice(3).every(args => !args.includes('--dry-run')));
+});
+
+test('retry skips only packages whose registry integrity matches', t => {
+  const f = fixture(t); f.save();
+  const first = f.manifest.packages[0];
+  const result = f.run(['publish', join(f.root, 'packed'), '--publish'], {
+    VIEW_RESPONSES: JSON.stringify({ [`${first.name}@1.2.3`]: { integrity: first.integrity } }),
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(f.calls().filter(args => args[0] === 'publish').map(args => args[1]), f.manifest.packages.slice(1).map(pkg => join(f.root, 'packed', pkg.filename)));
+});
+
+for (const response of [{ integrity: 'sha512-different' }, { error: 'E403' }]) {
+  test(`registry conflict or lookup failure causes no uploads: ${JSON.stringify(response)}`, t => {
+    const f = fixture(t); f.save();
+    const result = f.run(['publish', join(f.root, 'packed'), '--publish'], {
+      VIEW_RESPONSES: JSON.stringify({ '@0xff-ai/arena0@1.2.3': response }),
+    });
+    assert.notEqual(result.status, 0);
+    assert.equal(f.calls().filter(args => args[0] === 'publish').length, 0);
+  });
+}
+
+for (const [name, mutate] of [
+  ['wrong commit', f => { f.manifest.revision = 'other'; }],
+  ['wrong version', f => { f.manifest.version = '9.0.0'; }],
+  ['missing package', f => { f.manifest.packages.pop(); }],
+  ['wrong order', f => { f.manifest.packages.reverse(); }],
+  ['tampered tarball', f => writeFileSync(join(f.root, 'packed', f.manifest.packages[0].filename), 'changed')],
+  ['path traversal', f => { f.manifest.packages[0].filename = '../outside.tgz'; }],
+]) {
+  test(`rejects ${name} before invoking npm`, t => {
+    const f = fixture(t); mutate(f); f.save();
+    const result = f.run();
+    assert.notEqual(result.status, 0);
+    assert.deepEqual(f.calls(), []);
+  });
+}
+
+for (const [name, mutate] of [
+  ['dirty artifacts', f => { f.manifest.dirty = true; }],
+  ['dirty checkout', f => writeFileSync(join(f.root, 'Cargo.toml'), '[workspace.package]\nversion = "1.2.3"\n# changed\n')],
+  ['single-platform candidate', f => { f.manifest.platforms.shift(); f.manifest.packages.shift(); }],
+]) {
+  test(`${name} permits dry run but forbids publication`, t => {
+    const f = fixture(t); mutate(f); f.save();
+    const blocked = f.run(['publish', join(f.root, 'packed'), '--publish']);
+    assert.notEqual(blocked.status, 0);
+    assert.deepEqual(f.calls(), []);
+    const dryRun = f.run();
+    assert.equal(dryRun.status, 0, dryRun.stderr);
+  });
+}
+
+for (const problem of ['missing manifest', 'wrong revision', 'wrong version', 'wrong checksum', 'missing second platform']) {
+  test(`packing fails closed for ${problem}`, t => {
+    const f = fixture(t);
+    const dir = join(f.root, 'dist/darwin-arm64'); mkdirSync(dir, { recursive: true });
+    const artifact = { platform: 'darwin-arm64', version: '1.2.3', revision: f.manifest.revision, dirty: false, binaries: {} };
+    for (const binary of ['arena0', 'arena0d', 'cargo-arena0']) {
+      writeFileSync(join(dir, binary), binary);
+      artifact.binaries[binary] = createHash('sha256').update(binary).digest('hex');
+    }
+    if (problem === 'wrong revision') artifact.revision = 'other';
+    if (problem === 'wrong version') artifact.version = '9.0.0';
+    if (problem === 'wrong checksum') artifact.binaries.arena0 = 'incorrect';
+    if (problem !== 'missing manifest') writeFileSync(join(dir, 'manifest.json'), JSON.stringify(artifact));
+    const output = join(f.root, 'candidate');
+    const args = ['pack', join(f.root, 'dist'), output];
+    if (problem !== 'missing second platform') args.push('darwin-arm64');
+    const result = f.run(args);
+    assert.notEqual(result.status, 0);
+    assert.ok(!existsSync(output));
+    assert.deepEqual(f.calls(), []);
+  });
+}

--- a/scripts/build-linux-release.sh
+++ b/scripts/build-linux-release.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+zig_version=0.15.2
+zigbuild_version=0.22.3
+target=x86_64-unknown-linux-gnu
+
+if [[ $(zig version) != "$zig_version" ]]; then
+  echo "Linux release builds require Zig $zig_version" >&2
+  exit 1
+fi
+if ! cargo-zigbuild --version | grep -Fqx "cargo-zigbuild $zigbuild_version"; then
+  echo "install cargo-zigbuild with: cargo install --locked --version $zigbuild_version cargo-zigbuild" >&2
+  exit 1
+fi
+rustup target add "$target"
+# Keep the configured compiler wrapper and tracing rustflags. The explicit
+# target makes Zig supply the glibc baseline independently of the build host.
+(
+  cd programs
+  cargo run --locked --manifest-path ../Cargo.toml -p cargo-arena0 -- build
+)
+cargo zigbuild --locked --profile optimized-release --target "$target.2.35" \
+  -p arena0-cli -p arena0d -p cargo-arena0
+target_dir=$(cargo metadata --no-deps --format-version 1 | node -e \
+  'let s=""; process.stdin.on("data", b => s += b); process.stdin.on("end", () => console.log(JSON.parse(s).target_directory))')
+directory="$target_dir/$target/optimized-release"
+"$repo_root/scripts/check-linux-artifacts.sh" "$directory"
+echo "Linux release binaries: $directory"
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "directory=$directory" >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/npm-dry-run.sh
+++ b/scripts/npm-dry-run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+directory=${1:?usage: npm-dry-run.sh BINARY_DIRECTORY}
+platform=$(node -p 'process.platform + "-" + process.arch')
+output=$(mktemp -d "${TMPDIR:-/tmp}/arena0-npm-dry-run.XXXXXX")
+echo "Dry-run artifacts and logs are retained at $output"
+node scripts/stage-release.mjs "$platform" "$directory" "$output/dist/$platform"
+node npm/release.mjs pack "$output/dist" "$output/packed" "$platform"
+scripts/publish-npm.sh "$output/packed" --dry-run
+if [[ "$platform" == linux-x64 ]]; then
+  scripts/test-linux-package.sh "$output/packed"
+else
+  ARENA0_NPM_TARBALL_DIR="$output/packed" scripts/test-npm-package.sh "$platform"
+fi
+echo "Dry run passed for $platform. No packages were published. Tarballs: $output/packed"

--- a/scripts/npm-smoke.Dockerfile
+++ b/scripts/npm-smoke.Dockerfile
@@ -1,0 +1,10 @@
+# Node's official Linux binary supports Ubuntu 22.04's glibc. Only the runtime
+# and npm are copied; all runtime library resolution happens against 2.35.
+FROM node:22-bookworm-slim AS node
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libstdc++6 cargo \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
+WORKDIR /repo

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -1,30 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-: "${ARENA0_RELEASE_VERSION:?set ARENA0_RELEASE_VERSION to the resolved release version}"
-: "${NODE_AUTH_TOKEN:?set NODE_AUTH_TOKEN to publish arena0 npm packages}"
-
-packages=(
-  npm/arena0-darwin-arm64
-  npm/arena0-linux-x64
-  npm/arena0
-)
-
-cd "$repo_root"
-for directory in "${packages[@]}"; do
-  name=$(node -p "require('./$directory/package.json').name")
-  version=$(node -p "require('./$directory/package.json').version")
-  if [ "$version" != "$ARENA0_RELEASE_VERSION" ]; then
-    echo "$name version $version does not match release version $ARENA0_RELEASE_VERSION" >&2
-    exit 1
-  fi
-
-  published=$(npm view "$name@$version" version --json 2>/dev/null || true)
-  if [ "$published" = "\"$version\"" ]; then
-    echo "$name $version is already published"
-    continue
-  fi
-
-  npm publish --access public --provenance "./$directory"
-done
+# Only --publish permits registry writes; the default is a dry run of the
+# same checksummed tarballs already exercised by the package smoke test.
+exec node "$repo_root/npm/release.mjs" publish "${1:?usage: publish-npm.sh PACKED_DIRECTORY [--dry-run|--publish]}" "${2:---dry-run}"

--- a/scripts/resolve-release-run.mjs
+++ b/scripts/resolve-release-run.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+// Select only a successful main-push CI run for this exact release commit.
+import { spawnSync } from 'node:child_process';
+import { appendFileSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+function run(command, args) {
+  const result = spawnSync(command, args, { cwd: root, encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
+  if (result.error || result.status !== 0) throw new Error(result.error?.message ?? `${command}: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
+try {
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!/^[\w.-]+\/[\w.-]+$/.test(repository ?? '')) throw new Error('GITHUB_REPOSITORY must identify owner/repository.');
+  const revision = run('git', ['rev-parse', 'HEAD']);
+  const version = readFileSync(join(root, 'Cargo.toml'), 'utf8').match(/\[workspace.package\][\s\S]*?version\s*=\s*"([^"]+)"/)[1];
+  const requested = process.env.RELEASE_VERSION;
+  if (requested && requested !== version) throw new Error(`Requested version ${requested} does not match workspace ${version}.`);
+  if (process.env.GITHUB_REF_TYPE === 'tag' && process.env.GITHUB_REF_NAME !== `v${version}`) {
+    throw new Error(`Release tag must be v${version}.`);
+  }
+  const requestedRun = process.env.CI_RUN_ID;
+  if (requestedRun && !/^[1-9]\d*$/.test(requestedRun)) throw new Error('CI_RUN_ID must be a positive integer.');
+  const valid = candidate => candidate.head_sha === revision && candidate.head_branch === 'main'
+    && candidate.event === 'push' && candidate.status === 'completed' && candidate.conclusion === 'success'
+    && candidate.path === '.github/workflows/ci.yml'
+    && candidate.repository?.full_name?.toLowerCase() === repository.toLowerCase()
+    && candidate.head_repository?.full_name?.toLowerCase() === repository.toLowerCase()
+    && Number.isSafeInteger(candidate.id) && candidate.id > 0;
+  let selected;
+  if (requestedRun) {
+    selected = JSON.parse(run('gh', ['api', `repos/${repository}/actions/runs/${requestedRun}`]));
+    if (String(selected.id) !== requestedRun || !valid(selected)) throw new Error('Requested run is not successful main-push CI for this repository and exact commit.');
+  } else {
+    const pages = JSON.parse(run('gh', ['api', '--paginate', '--slurp',
+      `repos/${repository}/actions/workflows/ci.yml/runs?head_sha=${revision}&branch=main&event=push&status=success&per_page=100`]));
+    selected = pages.flatMap(page => page.workflow_runs).filter(valid).sort((a, b) => b.id - a.id)[0];
+    if (!selected) throw new Error(`No successful main-push CI run for ${revision}. Wait for CI, then rerun Release at this commit; artifacts are never taken from another commit.`);
+  }
+  const result = { run_id: selected.id, revision, version };
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, Object.entries(result).map(([key, value]) => `${key}=${value}\n`).join(''));
+  }
+  console.log(JSON.stringify(result));
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+}

--- a/scripts/resolve-release-run.mjs
+++ b/scripts/resolve-release-run.mjs
@@ -17,29 +17,19 @@ try {
   if (!/^[\w.-]+\/[\w.-]+$/.test(repository ?? '')) throw new Error('GITHUB_REPOSITORY must identify owner/repository.');
   const revision = run('git', ['rev-parse', 'HEAD']);
   const version = readFileSync(join(root, 'Cargo.toml'), 'utf8').match(/\[workspace.package\][\s\S]*?version\s*=\s*"([^"]+)"/)[1];
-  const requested = process.env.RELEASE_VERSION;
-  if (requested && requested !== version) throw new Error(`Requested version ${requested} does not match workspace ${version}.`);
   if (process.env.GITHUB_REF_TYPE === 'tag' && process.env.GITHUB_REF_NAME !== `v${version}`) {
     throw new Error(`Release tag must be v${version}.`);
   }
-  const requestedRun = process.env.CI_RUN_ID;
-  if (requestedRun && !/^[1-9]\d*$/.test(requestedRun)) throw new Error('CI_RUN_ID must be a positive integer.');
   const valid = candidate => candidate.head_sha === revision && candidate.head_branch === 'main'
     && candidate.event === 'push' && candidate.status === 'completed' && candidate.conclusion === 'success'
     && candidate.path === '.github/workflows/ci.yml'
     && candidate.repository?.full_name?.toLowerCase() === repository.toLowerCase()
     && candidate.head_repository?.full_name?.toLowerCase() === repository.toLowerCase()
     && Number.isSafeInteger(candidate.id) && candidate.id > 0;
-  let selected;
-  if (requestedRun) {
-    selected = JSON.parse(run('gh', ['api', `repos/${repository}/actions/runs/${requestedRun}`]));
-    if (String(selected.id) !== requestedRun || !valid(selected)) throw new Error('Requested run is not successful main-push CI for this repository and exact commit.');
-  } else {
-    const pages = JSON.parse(run('gh', ['api', '--paginate', '--slurp',
-      `repos/${repository}/actions/workflows/ci.yml/runs?head_sha=${revision}&branch=main&event=push&status=success&per_page=100`]));
-    selected = pages.flatMap(page => page.workflow_runs).filter(valid).sort((a, b) => b.id - a.id)[0];
-    if (!selected) throw new Error(`No successful main-push CI run for ${revision}. Wait for CI, then rerun Release at this commit; artifacts are never taken from another commit.`);
-  }
+  const pages = JSON.parse(run('gh', ['api', '--paginate', '--slurp',
+    `repos/${repository}/actions/workflows/ci.yml/runs?head_sha=${revision}&branch=main&event=push&status=success&per_page=100`]));
+  const selected = pages.flatMap(page => page.workflow_runs).filter(valid).sort((a, b) => b.id - a.id)[0];
+  if (!selected) throw new Error(`No successful main-push CI run for ${revision}. Wait for CI, then rerun Release at this commit; artifacts are never taken from another commit.`);
   const result = { run_id: selected.id, revision, version };
   if (process.env.GITHUB_OUTPUT) {
     appendFileSync(process.env.GITHUB_OUTPUT, Object.entries(result).map(([key, value]) => `${key}=${value}\n`).join(''));

--- a/scripts/resolve-release-run.test.mjs
+++ b/scripts/resolve-release-run.test.mjs
@@ -30,7 +30,7 @@ function fixture(t) {
       return spawnSync(process.execPath, [join(root, 'scripts/resolve-release-run.mjs')], {
         encoding: 'utf8', env: { ...process.env, PATH: `${root}/bin:${process.env.PATH}`,
           GITHUB_REPOSITORY: 'owner/arena0', GITHUB_OUTPUT: '', GITHUB_REF_TYPE: 'branch', GITHUB_REF_NAME: 'main',
-          RELEASE_VERSION: '', CI_RUN_ID: '', CALL_LOG: join(root, 'calls.json'), GH_RESPONSE: JSON.stringify(response), ...env },
+          CALL_LOG: join(root, 'calls.json'), GH_RESPONSE: JSON.stringify(response), ...env },
       });
     },
   };
@@ -46,28 +46,6 @@ test('automatic selection uses only successful main CI for the exact checkout', 
   assert.match(args.at(-1), new RegExp(`head_sha=${f.candidate.head_sha}&branch=main&event=push&status=success`));
 });
 
-test('explicit matching run is accepted and tag and requested version agree', t => {
-  const f = fixture(t);
-  const result = f.run(f.candidate, { CI_RUN_ID: '42', GITHUB_REF_TYPE: 'tag', GITHUB_REF_NAME: 'v1.2.3', RELEASE_VERSION: '1.2.3' });
-  assert.equal(result.status, 0, result.stderr);
-  assert.equal(JSON.parse(result.stdout).run_id, 42);
-});
-
-for (const [name, change] of Object.entries({
-  'wrong commit': { head_sha: 'other' }, 'wrong branch': { head_branch: 'feature' },
-  'PR event': { event: 'pull_request' }, 'unfinished run': { status: 'in_progress' },
-  'failed run': { conclusion: 'failure' }, 'other workflow': { path: '.github/workflows/release.yml' },
-  'other repository': { repository: { full_name: 'other/arena0' } },
-  'fork source': { head_repository: { full_name: 'fork/arena0' } }, 'wrong run ID': { id: 43 },
-})) {
-  test(`explicit selection rejects ${name}`, t => {
-    const f = fixture(t);
-    const result = f.run({ ...f.candidate, ...change }, { CI_RUN_ID: '42' });
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /Requested run is not successful/);
-  });
-}
-
 test('no exact successful run fails without falling back to another commit', t => {
   const f = fixture(t);
   const result = f.run([{ workflow_runs: [] }]);
@@ -75,11 +53,9 @@ test('no exact successful run fails without falling back to another commit', t =
   assert.match(result.stderr, /Wait for CI/);
 });
 
-for (const env of [{ RELEASE_VERSION: '9.0.0' }, { GITHUB_REF_TYPE: 'tag', GITHUB_REF_NAME: 'v9.0.0' }, { CI_RUN_ID: '../42' }]) {
-  test(`invalid release identity fails before GitHub lookup: ${JSON.stringify(env)}`, t => {
-    const f = fixture(t);
-    const result = f.run(f.candidate, env);
-    assert.notEqual(result.status, 0);
-    assert.throws(() => readFileSync(join(f.root, 'calls.json')), { code: 'ENOENT' });
-  });
-}
+test('tag must match the workspace version before GitHub lookup', t => {
+  const f = fixture(t);
+  const result = f.run([], { GITHUB_REF_TYPE: 'tag', GITHUB_REF_NAME: 'v9.0.0' });
+  assert.notEqual(result.status, 0);
+  assert.throws(() => readFileSync(join(f.root, 'calls.json')), { code: 'ENOENT' });
+});

--- a/scripts/resolve-release-run.test.mjs
+++ b/scripts/resolve-release-run.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+function fixture(t) {
+  const root = mkdtempSync(join(tmpdir(), 'arena0-resolve-test-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  mkdirSync(join(root, 'scripts'));
+  mkdirSync(join(root, 'bin'));
+  copyFileSync(new URL('./resolve-release-run.mjs', import.meta.url), join(root, 'scripts/resolve-release-run.mjs'));
+  writeFileSync(join(root, 'Cargo.toml'), '[workspace.package]\nversion = "1.2.3"\n');
+  for (const args of [['init', '-q'], ['add', '.'], ['-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '-qm', 'fixture']]) {
+    assert.equal(spawnSync('git', args, { cwd: root }).status, 0);
+  }
+  const revision = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).stdout.trim();
+  const candidate = {
+    id: 42, head_sha: revision, head_branch: 'main', event: 'push', status: 'completed', conclusion: 'success',
+    path: '.github/workflows/ci.yml', repository: { full_name: 'owner/arena0' }, head_repository: { full_name: 'owner/arena0' },
+  };
+  writeFileSync(join(root, 'bin/gh'), `#!${process.execPath}\nimport('node:fs').then(fs => {
+    fs.writeFileSync(process.env.CALL_LOG, JSON.stringify(process.argv.slice(2)));
+    console.log(process.env.GH_RESPONSE);
+  });\n`, { mode: 0o755 });
+  return {
+    root, candidate,
+    run(response, env = {}) {
+      return spawnSync(process.execPath, [join(root, 'scripts/resolve-release-run.mjs')], {
+        encoding: 'utf8', env: { ...process.env, PATH: `${root}/bin:${process.env.PATH}`,
+          GITHUB_REPOSITORY: 'owner/arena0', GITHUB_OUTPUT: '', GITHUB_REF_TYPE: 'branch', GITHUB_REF_NAME: 'main',
+          RELEASE_VERSION: '', CI_RUN_ID: '', CALL_LOG: join(root, 'calls.json'), GH_RESPONSE: JSON.stringify(response), ...env },
+      });
+    },
+  };
+}
+
+test('automatic selection uses only successful main CI for the exact checkout', t => {
+  const f = fixture(t);
+  const result = f.run([{ workflow_runs: [{ ...f.candidate, id: 99, head_sha: 'wrong' }, f.candidate] }]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), { run_id: 42, revision: f.candidate.head_sha, version: '1.2.3' });
+  const args = JSON.parse(readFileSync(join(f.root, 'calls.json'), 'utf8'));
+  assert.ok(args.includes('--paginate'));
+  assert.match(args.at(-1), new RegExp(`head_sha=${f.candidate.head_sha}&branch=main&event=push&status=success`));
+});
+
+test('explicit matching run is accepted and tag and requested version agree', t => {
+  const f = fixture(t);
+  const result = f.run(f.candidate, { CI_RUN_ID: '42', GITHUB_REF_TYPE: 'tag', GITHUB_REF_NAME: 'v1.2.3', RELEASE_VERSION: '1.2.3' });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(JSON.parse(result.stdout).run_id, 42);
+});
+
+for (const [name, change] of Object.entries({
+  'wrong commit': { head_sha: 'other' }, 'wrong branch': { head_branch: 'feature' },
+  'PR event': { event: 'pull_request' }, 'unfinished run': { status: 'in_progress' },
+  'failed run': { conclusion: 'failure' }, 'other workflow': { path: '.github/workflows/release.yml' },
+  'other repository': { repository: { full_name: 'other/arena0' } },
+  'fork source': { head_repository: { full_name: 'fork/arena0' } }, 'wrong run ID': { id: 43 },
+})) {
+  test(`explicit selection rejects ${name}`, t => {
+    const f = fixture(t);
+    const result = f.run({ ...f.candidate, ...change }, { CI_RUN_ID: '42' });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Requested run is not successful/);
+  });
+}
+
+test('no exact successful run fails without falling back to another commit', t => {
+  const f = fixture(t);
+  const result = f.run([{ workflow_runs: [] }]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Wait for CI/);
+});
+
+for (const env of [{ RELEASE_VERSION: '9.0.0' }, { GITHUB_REF_TYPE: 'tag', GITHUB_REF_NAME: 'v9.0.0' }, { CI_RUN_ID: '../42' }]) {
+  test(`invalid release identity fails before GitHub lookup: ${JSON.stringify(env)}`, t => {
+    const f = fixture(t);
+    const result = f.run(f.candidate, env);
+    assert.notEqual(result.status, 0);
+    assert.throws(() => readFileSync(join(f.root, 'calls.json')), { code: 'ENOENT' });
+  });
+}

--- a/scripts/stage-release.mjs
+++ b/scripts/stage-release.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const [platform, source, destination] = process.argv.slice(2);
+if (!['linux-x64', 'darwin-arm64'].includes(platform) || !source || !destination) {
+  throw new Error('Usage: node scripts/stage-release.mjs <platform> <binary-directory> <output-directory>');
+}
+if (platform !== `${process.platform}-${process.arch}`) throw new Error('Stage binaries on their native platform so their versions can be checked.');
+const run = (command, args) => {
+  const result = spawnSync(command, args, { cwd: root, encoding: 'utf8' });
+  if (result.error || result.status !== 0) throw new Error(result.error?.message ?? result.stderr);
+  return result.stdout.trim();
+};
+const version = readFileSync(join(root, 'Cargo.toml'), 'utf8').match(/\[workspace.package\][\s\S]*?version\s*=\s*"([^"]+)"/)[1];
+const manifest = {
+  version, platform, revision: run('git', ['rev-parse', 'HEAD']),
+  dirty: run('git', ['status', '--porcelain', '--untracked-files=no']) !== '',
+  binaries: {},
+};
+if (platform === 'linux-x64') run(join(root, 'scripts/check-linux-artifacts.sh'), [resolve(source)]);
+mkdirSync(destination, { recursive: true });
+for (const name of ['arena0', 'arena0d', 'cargo-arena0']) {
+  const file = resolve(source, name);
+  if (run(file, ['--version']) !== `${name} ${version}`) throw new Error(`${name} version does not match ${version}`);
+  const hash = createHash('sha256').update(readFileSync(file)).digest('hex');
+  copyFileSync(file, join(destination, name));
+  manifest.binaries[name] = hash;
+}
+writeFileSync(join(destination, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
+console.log(`Staged ${platform} ${version} at ${manifest.revision}${manifest.dirty ? ' (dirty checkout; dry run only)' : ''}`);

--- a/scripts/test-linux-package.sh
+++ b/scripts/test-linux-package.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+packed=$(cd "${1:?usage: test-linux-package.sh PACKED_DIRECTORY}" && pwd)
+# Build dependencies may use the network, but installing and running the
+# already-packed candidate must work without registry access.
+docker build -t arena0-npm-smoke:ubuntu22 -f "$repo_root/scripts/npm-smoke.Dockerfile" "$repo_root/scripts"
+docker run --rm --network=none --platform linux/amd64 \
+  -v "$repo_root:/repo:ro" -v "$packed:/packages:ro" \
+  -e ARENA0_NPM_TARBALL_DIR=/packages arena0-npm-smoke:ubuntu22 \
+  bash scripts/test-npm-package.sh linux-x64

--- a/scripts/test-npm-package.sh
+++ b/scripts/test-npm-package.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-target=${1:-$(node -p '`${process.platform}-${process.arch}`')}
+native_target=$(node -p 'process.platform + "-" + process.arch')
+target=${1:-$native_target}
 platform_package="$repo_root/npm/arena0-$target"
 main_package="$repo_root/npm/arena0"
-expected_version=$(node -p "require('$main_package/package.json').version")
+expected_version=$(sed -n '/^\[workspace.package\]/,/^\[/s/^version = "\([^"]*\)"/\1/p' "$repo_root/Cargo.toml")
 
 case "$target" in
   darwin-arm64 | linux-x64) ;;
@@ -14,32 +15,56 @@ case "$target" in
     exit 2
     ;;
 esac
-if [[ "$target" != "$(node -p '`${process.platform}-${process.arch}`')" ]]; then
-  echo "cannot execute $target binaries on $(node -p '`${process.platform}-${process.arch}`')" >&2
+if [[ "$target" != "$native_target" ]]; then
+  echo "cannot execute $target binaries on $native_target" >&2
   exit 2
 fi
-for binary in arena0 arena0d cargo-arena0; do
-  if [[ ! -x "$platform_package/bin/$binary" ]]; then
-    echo "missing packaged executable: $platform_package/bin/$binary" >&2
-    exit 1
-  fi
-done
+if [[ -z "${ARENA0_NPM_TARBALL_DIR:-}" ]]; then
+  for binary in arena0 arena0d cargo-arena0; do
+    if [[ ! -x "$platform_package/bin/$binary" ]]; then
+      echo "missing packaged executable: $platform_package/bin/$binary" >&2
+      exit 1
+    fi
+  done
+fi
 
 if [[ -n "${ARENA0_NPM_PREFIX:-}" ]]; then
   smoke_root=$ARENA0_NPM_PREFIX
   mkdir -p "$smoke_root"
 else
   smoke_root=$(mktemp -d "${TMPDIR:-/tmp}/arena0-npm-smoke.XXXXXX")
-  cleanup() {
-    rm -rf -- "$smoke_root"
-  }
-  trap cleanup EXIT
 fi
+service_pid=
+cleanup() {
+  if [[ -n "$service_pid" ]]; then
+    child_pid=$(pgrep -P "$service_pid" | head -n 1 || true)
+    kill -TERM "$service_pid" 2>/dev/null || true
+    for ((attempt = 0; attempt < 50; attempt++)); do
+      if ! kill -0 "$service_pid" 2>/dev/null; then break; fi
+      sleep 0.1
+    done
+    if [[ -n "$child_pid" ]] && kill -0 "$child_pid" 2>/dev/null; then
+      kill -KILL -- "-$child_pid" 2>/dev/null || true
+    fi
+    kill -KILL "$service_pid" 2>/dev/null || true
+    wait "$service_pid" || true
+  fi
+  if [[ -z "${ARENA0_NPM_PREFIX:-}" ]]; then
+    rm -rf -- "$smoke_root"
+  fi
+}
+trap cleanup EXIT
 
-platform_tarball=$(npm pack --silent --pack-destination "$smoke_root" "$platform_package")
-main_tarball=$(npm pack --silent --pack-destination "$smoke_root" "$main_package")
-npm install --silent --ignore-scripts --omit=optional --prefix "$smoke_root/install" \
-  "$smoke_root/$platform_tarball" "$smoke_root/$main_tarball"
+if [[ -n "${ARENA0_NPM_TARBALL_DIR:-}" ]]; then
+  # Consume the exact candidate tarballs; never re-pack after validation.
+  platform_tarball="$ARENA0_NPM_TARBALL_DIR/0xff-ai-arena0-$target-$expected_version.tgz"
+  main_tarball="$ARENA0_NPM_TARBALL_DIR/0xff-ai-arena0-$expected_version.tgz"
+else
+  platform_tarball="$smoke_root/$(npm pack --silent --pack-destination "$smoke_root" "$platform_package")"
+  main_tarball="$smoke_root/$(npm pack --silent --pack-destination "$smoke_root" "$main_package")"
+fi
+npm install --offline --ignore-scripts --omit=optional --no-audit --no-fund --prefix "$smoke_root/install" \
+  "$platform_tarball" "$main_tarball"
 
 bin_dir="$smoke_root/install/node_modules/.bin"
 example_dir="$smoke_root/install/node_modules/@0xff-ai/arena0/examples/minimal-program"
@@ -76,3 +101,38 @@ if (value.name !== "arena0" || value.markdown !== markdown) {
 }
 ' "$skill_json_file" "$repo_root/skills/arena0/SKILL.md"
 echo "npm smoke test installed and ran arena0, arena0d, cargo-arena0, and arena0 skill"
+
+# Exercise the installed CLI, sibling daemon, embedded program and replay
+# verifier. The private home also prevents interference with another daemon.
+env -u ARENA0_CONTEXT -u CODEX_THREAD_ID -u ARENA0_SOCKET -u ARENA0_HOST \
+  ARENA0_HOME="$smoke_root/home" "$bin_dir/arena0" serve > "$smoke_root/serve.log" 2>&1 &
+service_pid=$!
+for ((attempt = 0; attempt < 200; attempt++)); do
+  if [[ -S "$smoke_root/home/arena0.sock" ]]; then break; fi
+  if ! kill -0 "$service_pid" 2>/dev/null; then
+    cat "$smoke_root/serve.log" >&2
+    echo "installed arena0 serve exited before readiness" >&2
+    exit 1
+  fi
+  sleep 0.1
+done
+if [[ ! -S "$smoke_root/home/arena0.sock" ]]; then
+  cat "$smoke_root/serve.log" >&2
+  echo "installed arena0 serve did not become ready within 20 seconds" >&2
+  exit 1
+fi
+env -u ARENA0_CONTEXT -u CODEX_THREAD_ID -u ARENA0_SOCKET -u ARENA0_HOST \
+  ARENA0_HOME="$smoke_root/home" "$bin_dir/arena0" --json run rock-paper-scissors \
+  --builtin host-01=sample --builtin host-02=sample --replay \
+  > "$smoke_root/interaction.json"
+node - "$smoke_root/interaction.json" <<'JS'
+const assert = require('node:assert/strict');
+const result = JSON.parse(require('node:fs').readFileSync(process.argv[2], 'utf8'));
+assert.equal(result.exec, 'completed');
+assert.equal(result.verified.tier, 'full');
+assert.equal(result.verified.all_verified, true);
+assert.equal(result.verified.shared_evidence_agrees, true);
+assert.equal(result.verified.receipts.length, 2);
+assert.equal(new Set(result.verified.receipts.map(receipt => receipt.peer_id)).size, 2);
+JS
+echo "npm smoke test completed and replay-verified an interaction between two participants"

--- a/scripts/test-release-candidate.sh
+++ b/scripts/test-release-candidate.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 release_dir=${ARENA0_RELEASE_DIR:-$repo_root/target/optimized-release}
-target=$(node -p '`${process.platform}-${process.arch}`')
+target=$(node -p 'process.platform + "-" + process.arch')
 smoke_root=$(mktemp -d "${TMPDIR:-/tmp}/arena0-release-smoke.XXXXXX")
 service_pid=
 
@@ -35,7 +35,9 @@ case "$target" in
     ;;
 esac
 
-node "$repo_root/npm/assemble.mjs" "$target" "$release_dir"
+if [[ -z "${ARENA0_NPM_TARBALL_DIR:-}" ]]; then
+  node "$repo_root/npm/assemble.mjs" "$target" "$release_dir"
+fi
 ARENA0_NPM_PREFIX="$smoke_root/npm" \
   "$repo_root/scripts/test-npm-package.sh" "$target"
 
@@ -141,7 +143,7 @@ if [[ -S "$socket" ]]; then
   echo "installed arena0 serve left the daemon socket behind" >&2
   exit 1
 fi
-if [[ $(grep -c 'arena0d stopped' "$log") -ne 2 ]]; then
+if [[ $(grep -c 'arena0d Host stopped' "$log") -ne 2 ]]; then
   cat "$log" >&2
   echo "installed arena0 serve did not report both Hosts stopped" >&2
   exit 1


### PR DESCRIPTION
## Summary

- build macOS arm64 and portable glibc 2.35 Linux x64 release artifacts after successful main-push CI
- bind artifacts to the exact source revision and workspace version with executable checksums
- pack npm tarballs once, retain their integrity manifest, and publish those exact bytes in platform-before-wrapper order
- make manual releases and local package workflows dry-run by default, with offline Ubuntu 22.04 and external SDK smoke coverage

## Release behavior

Release selects only a successful main-push CI run from this repository at the exact checked-out commit. It never falls back to another revision or rebuilds executables. Registry writes remain limited to tag pushes or an explicit publish input; dirty, partial, mismatched, or modified candidates fail closed.