### PR TITLE
fix(ci): correct Zig setup action pin

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Install Zig
         if: matrix.target == 'linux-x64'
-        uses: mlugg/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.15.2
 


### PR DESCRIPTION
Release artifact jobs fail during setup because the pinned mlugg/setup-zig commit does not exist. Pin the verified v2.2.1 commit so both platform builds can start.