### PR TITLE
ci: run Linux pipelines on Ficus and fix macOS build command

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -21,7 +21,7 @@ jobs:
             os: macos-14
             release_dir: target/optimized-release
           - target: linux-x64
-            os: ubuntu-26.04
+            os: arena0-ficus
             release_dir: target/x86_64-unknown-linux-gnu/optimized-release
     runs-on: ${{ matrix.os }}
     steps:
@@ -38,6 +38,8 @@ jobs:
         run: echo "identity=$(rustc -vV | git hash-object --stdin)" >> "$GITHUB_OUTPUT"
 
       - name: Restore Rust cache
+        # Ficus uses its configured machine-local compiler cache.
+        if: runner.environment == 'github-hosted'
         id: rust-cache
         continue-on-error: true
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -121,7 +123,7 @@ jobs:
           retention-days: 90
 
       - name: Save Rust cache
-        if: ${{ !cancelled() && steps.rust-cache.outputs.cache-primary-key != '' }}
+        if: ${{ !cancelled() && runner.environment == 'github-hosted' && steps.rust-cache.outputs.cache-primary-key != '' }}
         continue-on-error: true
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -68,8 +68,9 @@ jobs:
 
       - name: Build public executables
         if: matrix.target == 'darwin-arm64'
-        run: cargo build --locked --profile optimized-release \
-          -p arena0-cli -p arena0d -p cargo-arena0
+        run: |
+          cargo build --locked --profile optimized-release \
+            -p arena0-cli -p arena0d -p cargo-arena0
 
       - name: Install Zig
         if: matrix.target == 'linux-x64'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,7 @@ jobs:
   # Steps are ordered fast-fail: formatting and clippy run before the test phase.
   check:
     name: fmt + clippy + test
-    # Main pushes and same-repository PRs use Ficus; fork PRs use a hosted runner.
-    runs-on: >-
-      ${{ (github.event_name == 'push' ||
-          github.event.pull_request.head.repo.full_name == github.repository)
-          && 'arena0-ficus' || 'ubuntu-26.04' }}
+    runs-on: arena0-ficus
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   publish:
     name: verify and promote artifacts
-    runs-on: ubuntu-26.04
+    runs-on: arena0-ficus
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
Route all Linux CI checks, release artifact builds, and publication jobs to arena0-ficus, preserving its configured compiler cache. Keep native macOS builds on macos-14. Fix the macOS Cargo command to preserve shell line continuations so artifact builds can complete.