### PR TITLE
fix(build): target release C dependencies with Zig

### DIFF
--- a/scripts/build-linux-release.sh
+++ b/scripts/build-linux-release.sh
@@ -22,6 +22,12 @@ rustup target add "$target"
   cd programs
   cargo run --locked --manifest-path ../Cargo.toml -p cargo-arena0 -- build
 )
+# AWS-LC prefers HOST_CC/HOST_CXX when the Rust host and target triples match,
+# even though this build targets an older glibc. Override native compiler
+# defaults only for this invocation so C objects use the same baseline as the
+# Zig linker. The configured Rust compiler wrapper remains in effect.
+HOST_CC="cargo-zigbuild zig cc -- -target x86_64-linux-gnu.2.35" \
+HOST_CXX="cargo-zigbuild zig c++ -- -target x86_64-linux-gnu.2.35" \
 cargo zigbuild --locked --profile optimized-release --target "$target.2.35" \
   -p arena0-cli -p arena0d -p cargo-arena0
 target_dir=$(cargo metadata --no-deps --format-version 1 | node -e \


### PR DESCRIPTION
On Ficus, AWS-LC gives HOST_CC and HOST_CXX precedence over cargo-zigbuild target compiler settings because the Rust host and target triples match. Native C objects then reference glibc 2.38 symbols and fail to link against the release’s 2.35 baseline. Scope those variables to cargo-zigbuild’s C and C++ frontends for the release invocation, retaining the configured Rust compiler wrapper and normal native build settings.