### PR TITLE
ci: use hosted release runners and fix macOS smoke paths

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -21,7 +21,7 @@ jobs:
             os: macos-14
             release_dir: target/optimized-release
           - target: linux-x64
-            os: arena0-ficus
+            os: ubuntu-22.04
             release_dir: target/x86_64-unknown-linux-gnu/optimized-release
     runs-on: ${{ matrix.os }}
     steps:
@@ -38,8 +38,6 @@ jobs:
         run: echo "identity=$(rustc -vV | git hash-object --stdin)" >> "$GITHUB_OUTPUT"
 
       - name: Restore Rust cache
-        # Ficus uses its configured machine-local compiler cache.
-        if: runner.environment == 'github-hosted'
         id: rust-cache
         continue-on-error: true
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -123,7 +121,7 @@ jobs:
           retention-days: 90
 
       - name: Save Rust cache
-        if: ${{ !cancelled() && runner.environment == 'github-hosted' && steps.rust-cache.outputs.cache-primary-key != '' }}
+        if: ${{ !cancelled() && steps.rust-cache.outputs.cache-primary-key != '' }}
         continue-on-error: true
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   publish:
     name: verify and promote artifacts
-    runs-on: arena0-ficus
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       actions: read

--- a/scripts/test-npm-package.sh
+++ b/scripts/test-npm-package.sh
@@ -32,8 +32,11 @@ if [[ -n "${ARENA0_NPM_PREFIX:-}" ]]; then
   smoke_root=$ARENA0_NPM_PREFIX
   mkdir -p "$smoke_root"
 else
-  smoke_root=$(mktemp -d "${TMPDIR:-/tmp}/arena0-npm-smoke.XXXXXX")
+  # Leave room for the daemon socket within the Unix socket path limit.
+  smoke_root=$(mktemp -d /tmp/arena0-npm.XXXXXX)
 fi
+# macOS /tmp and caller-provided prefixes may contain symlink ancestors.
+smoke_root=$(cd "$smoke_root" && pwd -P)
 service_pid=
 cleanup() {
   if [[ -n "$service_pid" ]]; then

--- a/scripts/test-release-candidate.sh
+++ b/scripts/test-release-candidate.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 release_dir=${ARENA0_RELEASE_DIR:-$repo_root/target/optimized-release}
 target=$(node -p 'process.platform + "-" + process.arch')
-smoke_root=$(mktemp -d "${TMPDIR:-/tmp}/arena0-release-smoke.XXXXXX")
+# Keep Unix socket paths short on macOS, where TMPDIR can be deeply nested.
+# Resolve /tmp itself because the daemon rejects symlinked home ancestors.
+smoke_root=$(mktemp -d /tmp/arena0-release.XXXXXX)
+smoke_root=$(cd "$smoke_root" && pwd -P)
 service_pid=
 
 cleanup() {


### PR DESCRIPTION
Run Linux release artifact builds and publication on GitHub-hosted Ubuntu 22.04 runners. Keep macOS artifacts on macos-14 and normal CI on Ficus. Restore the release artifact cache without the self-hosted runner condition.

Use short, physical temporary paths for the release smoke tests. macOS temporary-directory symlinks otherwise cause the installed daemon to reject its home before readiness; deeply nested temporary paths can also exceed Unix socket path limits.