### PR TITLE
ci: test published npm agent demos

### DIFF
--- a/.github/workflows/npm-agent-demos.yml
+++ b/.github/workflows/npm-agent-demos.yml
@@ -1,0 +1,65 @@
+name: Published npm agent demos
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-agent-demos-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  demos:
+    name: install and run all demos
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      - name: Prepare credential and published version
+        id: setup
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [[ -z "$OPENAI_API_KEY" ]]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "### Published npm agent demos" >> "$GITHUB_STEP_SUMMARY"
+            echo "Skipped until the repository secret \`OPENAI_API_KEY\` is configured." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          umask 077
+          credential="$RUNNER_TEMP/arena0-openai-api-key"
+          printf '%s' "$OPENAI_API_KEY" > "$credential"
+          version=$(npm view @0xff-ai/arena0 version)
+          {
+            echo "available=true"
+            echo "credential=$credential"
+            echo "version=$version"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run published package through every agent demo
+        if: steps.setup.outputs.available == 'true'
+        env:
+          ARENA0_NPM_VERSION: ${{ steps.setup.outputs.version }}
+        run: ./scripts/test-npm-agent-demos.sh "${{ steps.setup.outputs.credential }}"
+
+      - name: Remove credential
+        if: always() && steps.setup.outputs.available == 'true'
+        run: rm -f -- "${{ steps.setup.outputs.credential }}"
+
+      - name: Upload demo evidence
+        if: always() && steps.setup.outputs.available == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-agent-demos-${{ github.sha }}
+          path: output/npm-agent-demos
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/development.md
+++ b/docs/development.md
@@ -73,3 +73,28 @@ After stabilization, one integration owner runs the full gate. Workers run
 their assigned checks, and successful evidence is reused until relevant inputs
 change. See the [CI workflow](../.github/workflows/ci.yml) and
 [release workflow](../.github/workflows/release.yml) for the job wiring.
+
+## Published npm agent demos
+
+The [published npm demo workflow](../.github/workflows/npm-agent-demos.yml) runs
+only after pushes to `main`. It installs the current public
+`@0xff-ai/arena0` package into a clean Docker image, launches Chess,
+Prisoner's Dilemma, and Rock-Paper-Scissors with two autonomous Codex
+Participants, visits all six monitor views, and requires completed executions
+with matching Light-verified session receipts. The three demos run in parallel
+with low reasoning effort and fixed legal strategies, including a four-ply
+Fool's Mate for Chess. Each container has a ten-minute deadline, and the job
+retains its tmux transcripts and monitor captures as a CI artifact.
+
+Configure the `OPENAI_API_KEY` repository secret to enable the workflow. Until
+that secret exists, the job records a skip in its step summary without creating
+a credential file. To reproduce the same run locally, place the key in a
+mode-`0600` file and pass its path to the runner:
+
+```sh
+scripts/test-npm-agent-demos.sh /path/to/openai-api-key
+```
+
+The runner mounts that file read-only into each disposable container and feeds
+it to `codex login` on standard input. It defaults to the latest published
+arena0 package; set `ARENA0_NPM_VERSION` to test an exact registry version.

--- a/scripts/npm-agent-demo-e2e.Dockerfile
+++ b/scripts/npm-agent-demo-e2e.Dockerfile
@@ -1,0 +1,29 @@
+FROM node:22-bookworm-slim
+
+ARG ARENA0_VERSION=latest
+ARG CODEX_VERSION=0.153.4
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        locales \
+        procps \
+        python3 \
+        tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install from the public registries. The repository is copied only after npm
+# installation so this image cannot accidentally exercise workspace packages.
+RUN npm install --global \
+        "@0xff-ai/arena0@${ARENA0_VERSION}" \
+        "@openai/codex@${CODEX_VERSION}"
+
+COPY scripts/run-npm-agent-demo.sh /usr/local/bin/run-npm-agent-demo
+RUN chmod 0755 /usr/local/bin/run-npm-agent-demo
+
+ENV LANG=C.UTF-8
+ENV TERM=xterm-256color
+WORKDIR /work
+
+ENTRYPOINT ["/usr/local/bin/run-npm-agent-demo"]

--- a/scripts/run-npm-agent-demo.sh
+++ b/scripts/run-npm-agent-demo.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+program=${1:?usage: run-npm-agent-demo PROGRAM}
+session=arena0-e2e
+evidence=/evidence
+timeout_seconds=${ARENA0_DEMO_TIMEOUT_SECONDS:-600}
+
+if [[ ! "$timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ARENA0_DEMO_TIMEOUT_SECONDS must be a positive integer" >&2
+  exit 2
+fi
+
+case "$program" in
+  chess)
+    display_name=Chess
+    selection_steps=0
+    ;;
+  prisoner-dilemma)
+    display_name="Prisoner's Dilemma"
+    selection_steps=3
+    ;;
+  rock-paper-scissors)
+    display_name="Rock-Paper-Scissors"
+    selection_steps=4
+    ;;
+  *)
+    echo "unsupported agent demo: $program" >&2
+    exit 2
+    ;;
+esac
+
+if [[ ! -s /run/secrets/openai_api_key ]]; then
+  echo "the OpenAI API key secret is empty or unavailable" >&2
+  exit 1
+fi
+mkdir -p "$evidence"
+chmod 0700 "$evidence"
+
+# Codex stores its authenticated state in this disposable container. Feeding the
+# key on stdin keeps it out of the process arguments, environment, and evidence.
+codex login --with-api-key < /run/secrets/openai_api_key >/dev/null 2>&1
+codex login status >/dev/null 2>&1
+printf 'model_reasoning_effort = "low"\n' > /root/.codex/config.toml
+
+arena0_version=$(npm list --global --depth=0 @0xff-ai/arena0 --json | node -e '
+  let input = "";
+  process.stdin.on("data", chunk => input += chunk);
+  process.stdin.on("end", () => process.stdout.write(JSON.parse(input).dependencies["@0xff-ai/arena0"].version));
+')
+codex_version=$(codex --version | awk '{print $NF}')
+printf 'program=%s\narena0=%s\ncodex=%s\nreasoning=low\n' \
+  "$program" "$arena0_version" "$codex_version" > "$evidence/versions.txt"
+
+strip_ansi() {
+  python3 - "$1" "$2" <<'PY'
+import pathlib
+import re
+import sys
+
+source, destination = map(pathlib.Path, sys.argv[1:])
+text = source.read_text(errors="replace")
+text = re.sub(r"\x1b(?:[@-_][0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))", "", text)
+destination.write_text(text)
+PY
+}
+
+capture_pane() {
+  local target=$1
+  local destination=$2
+  tmux capture-pane -p -e -S - -t "$target" > "$destination.ansi"
+  strip_ansi "$destination.ansi" "$destination.txt"
+}
+
+cat > /tmp/arena0-launch.sh <<'SH'
+#!/usr/bin/env bash
+set +e
+arena0 launch --agents
+status=$?
+printf '%s\n' "$status" > /evidence/launcher.status
+exec sleep infinity
+SH
+chmod 0755 /tmp/arena0-launch.sh
+
+tmux new-session -d -x 180 -y 55 -s "$session" /tmp/arena0-launch.sh
+tmux set-option -t "$session" remain-on-exit on
+tmux set-option -t "$session" history-limit 100000
+
+launcher="$session:0.0"
+for ((attempt = 0; attempt < 60; attempt++)); do
+  capture_pane "$launcher" "$evidence/launcher-selection"
+  if grep -Fq 'PROGRAMS' "$evidence/launcher-selection.txt"; then
+    break
+  fi
+  sleep 1
+done
+if ! grep -Fq 'PROGRAMS' "$evidence/launcher-selection.txt"; then
+  echo "$program: launcher did not show the program catalog" >&2
+  exit 1
+fi
+
+# The published catalog is sorted by display name. Home plus a bounded number
+# of Down keys exercises the same selection path a user follows in the TUI.
+tmux send-keys -t "$launcher" g
+for ((step = 0; step < selection_steps; step++)); do
+  tmux send-keys -t "$launcher" Down
+done
+sleep 1
+capture_pane "$launcher" "$evidence/launcher-selected"
+if ! grep -Fq "▸ $display_name" "$evidence/launcher-selected.txt"; then
+  echo "$program: launcher selected a program other than $display_name" >&2
+  exit 1
+fi
+
+socket=
+for ((attempt = 0; attempt < 120; attempt++)); do
+  socket=$(find /root/.arena0/tmp -type s -name arena0.sock -print -quit 2>/dev/null || true)
+  [[ -n "$socket" ]] && break
+  sleep 1
+done
+if [[ -z "$socket" ]]; then
+  echo "$program: isolated arena0 daemon socket did not appear" >&2
+  exit 1
+fi
+demo_home=$(dirname "$socket")
+
+case "$program" in
+  chess)
+    cat > "$evidence/AGENTS.md" <<'EOF'
+# Bounded demo strategy
+
+Follow the arena0 launcher instructions and use this legal Fool's Mate sequence
+to keep the CI run bounded. Follow the authored position: submit `f2f3` from the
+starting position, `e7e5` after `f3`, `g2g4` after `e5`, and `d8h4` after `g4`.
+Submit only when the runtime gives your execution the move callout.
+EOF
+    ;;
+  prisoner-dilemma)
+    cat > "$evidence/AGENTS.md" <<'EOF'
+# Bounded demo strategy
+
+Follow the arena0 launcher instructions. Choose `Cooperate` on every turn and
+proceed immediately after printing the required authored view.
+EOF
+    ;;
+  rock-paper-scissors)
+    cat > "$evidence/AGENTS.md" <<'EOF'
+# Bounded demo strategy
+
+Follow the arena0 launcher instructions. The creator chooses `Rock` and the
+joiner chooses `Paper` on every turn. Proceed immediately after printing the
+required authored view; two joiner wins will end the game early.
+EOF
+    ;;
+esac
+cp "$evidence/AGENTS.md" "$demo_home/workspace/AGENTS.md"
+
+tmux send-keys -t "$launcher" Enter
+
+right_pane=
+for ((attempt = 0; attempt < 120; attempt++)); do
+  mapfile -t pane_ids < <(tmux list-panes -t "$session:0" -F '#{pane_id}')
+  if (( ${#pane_ids[@]} == 2 )); then
+    right_pane=${pane_ids[1]}
+    break
+  fi
+  if [[ -s "$evidence/launcher.status" ]]; then
+    break
+  fi
+  sleep 1
+done
+if [[ -z "$right_pane" ]]; then
+  capture_pane "$launcher" "$evidence/launcher-failed"
+  echo "$program: launcher did not create the second tmux pane" >&2
+  exit 1
+fi
+
+tmux new-window -d -t "$session" -n inspector \
+  "env ARENA0_HOME='$demo_home' arena0 monitor"
+inspector="$session:1.0"
+for ((attempt = 0; attempt < 60; attempt++)); do
+  capture_pane "$inspector" "$evidence/inspector-initial"
+  if grep -Fq 'MONITOR' "$evidence/inspector-initial.txt"; then
+    break
+  fi
+  sleep 1
+done
+if ! grep -Fq 'MONITOR' "$evidence/inspector-initial.txt"; then
+  echo "$program: inspector did not attach to the isolated run" >&2
+  exit 1
+fi
+
+for ((attempt = 0; attempt < 180; attempt++)); do
+  capture_pane "$inspector" "$evidence/inspector-ready"
+  if grep -Fq '2 executions' "$evidence/inspector-ready.txt" \
+      && grep -Fq 'ACTIVE' "$evidence/inspector-ready.txt"; then
+    break
+  fi
+  if [[ -s "$evidence/launcher.status" ]]; then
+    break
+  fi
+  sleep 1
+done
+if ! grep -Fq '2 executions' "$evidence/inspector-ready.txt" \
+    || ! grep -Fq 'ACTIVE' "$evidence/inspector-ready.txt"; then
+  echo "$program: inspector did not observe both active executions" >&2
+  exit 1
+fi
+
+# Visit and retain every inspector surface while the interaction is live.
+view_markers=('▸ Program' 'Negotiation stage' 'GUEST VIEW' 'PUBLIC TRACE' 'Wasm handlers' 'SYSTEM EVENTS')
+for view in 1 2 3 4 5 6; do
+  tmux send-keys -t "$inspector" "$view"
+  sleep 1
+  capture_pane "$inspector" "$evidence/inspector-view-$view"
+  if ! grep -Fq "${view_markers[$((view - 1))]}" "$evidence/inspector-view-$view.txt"; then
+    echo "$program: inspector view $view did not render its expected surface" >&2
+    exit 1
+  fi
+done
+
+started_at=$SECONDS
+next_report=0
+while [[ ! -s "$evidence/launcher.status" ]]; do
+  elapsed=$((SECONDS - started_at))
+  if (( elapsed >= timeout_seconds )); then
+    capture_pane "$launcher" "$evidence/agent-left-timeout"
+    capture_pane "$right_pane" "$evidence/agent-right-timeout"
+    capture_pane "$inspector" "$evidence/inspector-timeout"
+    echo "$program: timed out after ${timeout_seconds}s" >&2
+    exit 1
+  fi
+  if (( elapsed >= next_report )); then
+    capture_pane "$launcher" "$evidence/agent-left-progress"
+    capture_pane "$right_pane" "$evidence/agent-right-progress"
+    capture_pane "$inspector" "$evidence/inspector-progress"
+    printf '%s: participants still active after %ss\n' "$program" "$elapsed"
+    next_report=$((elapsed + 30))
+  fi
+  sleep 2
+done
+
+capture_pane "$launcher" "$evidence/agent-left-final"
+capture_pane "$right_pane" "$evidence/agent-right-final"
+tmux send-keys -t "$inspector" Escape
+sleep 1
+capture_pane "$inspector" "$evidence/inspector-final"
+
+status=$(<"$evidence/launcher.status")
+if [[ "$status" != 0 ]]; then
+  echo "$program: arena0 launch --agents exited with status $status" >&2
+  exit 1
+fi
+if ! grep -Fq 'both Codex Participants finished' "$evidence/agent-left-final.txt"; then
+  echo "$program: launcher did not report both participants finished" >&2
+  exit 1
+fi
+for transcript in "$evidence/agent-left-final.txt" "$evidence/agent-right-final.txt"; do
+  if ! grep -Fq 'arena0' "$transcript" \
+      || ! grep -Fq 'exec view' "$transcript" \
+      || ! grep -Fq 'receipt verify' "$transcript" \
+      || ! grep -Fq '"tier": "Light"' "$transcript" \
+      || ! grep -Fq '"Completed"' "$transcript"; then
+    echo "$program: participant transcript lacks authored views, completion, or Light receipt verification" >&2
+    exit 1
+  fi
+done
+if ! grep -Fq '2 Hosts' "$evidence/inspector-final.txt" \
+    || ! grep -Fq '2 executions' "$evidence/inspector-final.txt" \
+    || ! grep -Fq 'COMPLETED' "$evidence/inspector-final.txt"; then
+  echo "$program: inspector did not observe both completed executions" >&2
+  exit 1
+fi
+
+common_session=$(comm -12 \
+  <(grep -oE '"session_id": "[0-9a-f]{64}"' "$evidence/agent-left-final.txt" | sort -u) \
+  <(grep -oE '"session_id": "[0-9a-f]{64}"' "$evidence/agent-right-final.txt" | sort -u) \
+  | head -n 1)
+common_receipt=$(comm -12 \
+  <(grep -oE '"receipt_id": "[0-9a-f]{64}"' "$evidence/agent-left-final.txt" | sort -u) \
+  <(grep -oE '"receipt_id": "[0-9a-f]{64}"' "$evidence/agent-right-final.txt" | sort -u) \
+  | head -n 1)
+if [[ -z "$common_session" || -z "$common_receipt" ]]; then
+  echo "$program: participant transcripts did not report the same session and receipt" >&2
+  exit 1
+fi
+
+printf '%s: published npm demo completed with two agents, inspector coverage, and verified Light receipts\n' "$program"

--- a/scripts/test-npm-agent-demos.sh
+++ b/scripts/test-npm-agent-demos.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+credential_file=${1:?usage: test-npm-agent-demos.sh OPENAI_API_KEY_FILE [EVIDENCE_DIR]}
+evidence_base=${2:-$repo_root/output/npm-agent-demos}
+arena0_version=${ARENA0_NPM_VERSION:-latest}
+codex_version=${CODEX_NPM_VERSION:-0.153.4}
+demo_timeout=${ARENA0_DEMO_TIMEOUT_SECONDS:-600}
+run_id=${GITHUB_RUN_ID:-local}-$$
+image="arena0-npm-agent-demos:$run_id"
+programs=(chess prisoner-dilemma rock-paper-scissors)
+containers=()
+log_pids=()
+
+if [[ ! -s "$credential_file" ]]; then
+  echo "OpenAI API key file is empty or unavailable: $credential_file" >&2
+  exit 1
+fi
+credential_dir=$(cd "$(dirname "$credential_file")" && pwd -P)
+credential_file="$credential_dir/$(basename "$credential_file")"
+if [[ ! "$demo_timeout" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ARENA0_DEMO_TIMEOUT_SECONDS must be a positive integer" >&2
+  exit 2
+fi
+if ! command -v docker >/dev/null; then
+  echo "Docker is required for the published npm agent demos" >&2
+  exit 1
+fi
+
+cleanup() {
+  for pid in "${log_pids[@]}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  if (( ${#containers[@]} > 0 )); then
+    docker rm -f "${containers[@]}" >/dev/null 2>&1 || true
+  fi
+  docker image rm "$image" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+mkdir -p "$evidence_base"
+evidence_base=$(cd "$evidence_base" && pwd -P)
+evidence_root="$evidence_base/$run_id"
+mkdir "$evidence_root"
+
+docker build --pull \
+  --build-arg "ARENA0_VERSION=$arena0_version" \
+  --build-arg "CODEX_VERSION=$codex_version" \
+  --file "$repo_root/scripts/npm-agent-demo-e2e.Dockerfile" \
+  --tag "$image" \
+  "$repo_root"
+
+for program in "${programs[@]}"; do
+  destination="$evidence_root/$program"
+  mkdir -p "$destination"
+  container="arena0-npm-demo-${run_id//[^a-zA-Z0-9_.-]/-}-${program}"
+  containers+=("$container")
+  # Codex uses a nested sandbox for shell tools. Docker's default seccomp and
+  # AppArmor profiles block the required namespace and mount operations.
+  docker run -d --init \
+    --name "$container" \
+    --hostname "arena0-$program" \
+    --cap-add SYS_ADMIN \
+    --security-opt seccomp=unconfined \
+    --security-opt apparmor=unconfined \
+    --env "ARENA0_DEMO_TIMEOUT_SECONDS=$demo_timeout" \
+    --mount "type=bind,src=$credential_file,dst=/run/secrets/openai_api_key,readonly" \
+    --mount "type=bind,src=$destination,dst=/evidence" \
+    "$image" "$program" >/dev/null
+  docker logs --follow "$container" 2>&1 | sed -u "s/^/[$program] /" &
+  log_pids+=("$!")
+done
+
+failed=0
+for index in "${!containers[@]}"; do
+  container=${containers[$index]}
+  program=${programs[$index]}
+  status=$(docker wait "$container")
+  wait "${log_pids[$index]}" || true
+  if [[ "$status" != 0 ]]; then
+    echo "$program demo failed with container status $status" >&2
+    failed=1
+  fi
+done
+if (( failed )); then
+  exit 1
+fi
+
+echo "published @0xff-ai/arena0@$arena0_version completed all autonomous agent demos"
+echo "evidence: $evidence_root"


### PR DESCRIPTION
The published npm package had no recurring proof that a user could install it from scratch, launch two Codex Participants in tmux, inspect the live execution, and verify the resulting receipt. A natural Chess match also took long enough to make that journey unsuitable for every main push.

This adds a main-only workflow that installs the current public arena0 package in disposable Docker containers and runs Chess, Prisoner's Dilemma, and Rock-Paper-Scissors in parallel. Each run visits all six monitor views and requires both Codex transcripts to report the same completed session and Light receipt. Fixed legal strategies and low reasoning effort bound Chess to a four-ply Fool's Mate; each container has a ten-minute deadline and the job has a fifteen-minute deadline. The workflow records a clean skip until the `OPENAI_API_KEY` repository secret is configured and uploads the tmux and monitor evidence when enabled.
